### PR TITLE
Recorta references.bib a solo lo citado en la tesis

### DIFF
--- a/docs/references.bib
+++ b/docs/references.bib
@@ -1,37 +1,3 @@
-@misc{116ProbabilityCalibration,
-  title = {1.16. {{Probability}} Calibration},
-  journal = {scikit-learn},
-  urldate = {2025-09-20},
-  abstract = {When performing classification you often want not only to predict the class label, but also obtain a probability of the respective label. This probability gives you some kind of confidence on the p...},
-  howpublished = {https://scikit-learn/stable/modules/calibration.html},
-  langid = {english},
-  file = {/Users/gonzalo/Zotero/storage/PE3IHTS5/calibration.html}
-}
-
-@misc{AdelaideResearchScholarship2014,
-  title = {Adelaide {{Research}} and {{Scholarship}}: {{The Case}} of {{Zero Survivors}} in {{Prob}}\dots},
-  shorttitle = {Adelaide {{Research}} and {{Scholarship}}},
-  year = 2014,
-  month = apr,
-  journal = {archive.ph},
-  urldate = {2024-10-07},
-  howpublished = {https://archive.ph/0DrIB},
-  file = {/Users/gonzalo/Zotero/storage/MW6DIJMS/15223.html}
-}
-
-@article{AffineConnection2024,
-  title = {Affine Connection},
-  year = 2024,
-  month = jul,
-  journal = {Wikipedia},
-  urldate = {2025-09-01},
-  abstract = {In differential geometry, an affine connection is a geometric object on a smooth manifold which connects nearby tangent spaces, so it permits tangent vector fields to be differentiated as if they were functions on the manifold with values in a fixed vector space. Connections are among the simplest methods of defining differentiation of the sections of vector bundles. The notion of an affine connection has its roots in 19th-century geometry and tensor calculus, but was not fully developed until the early 1920s, by \'Elie Cartan (as part of his general theory of connections) and Hermann Weyl (who used the notion as a part of his foundations for general relativity). The terminology is due to Cartan and has its origins in the identification of tangent spaces in Euclidean space Rn by translation: the idea is that a choice of affine connection makes a manifold look infinitesimally like Euclidean space not just smoothly, but as an affine space. On any manifold of positive dimension there are infinitely many affine connections. If the manifold is further endowed with a metric tensor then there is a natural choice of affine connection, called the Levi-Civita connection. The choice of an affine connection is equivalent to prescribing a way of differentiating vector fields which satisfies several reasonable properties (linearity and the Leibniz rule). This yields a possible definition of an affine connection as a covariant derivative or (linear) connection on the tangent bundle. A choice of affine connection is also equivalent to a notion of parallel transport, which is a method for transporting tangent vectors along curves. This also defines a parallel transport on the frame bundle. Infinitesimal parallel transport in the frame bundle yields another description of an affine connection, either as a Cartan connection for the affine group or as a principal connection on the frame bundle. The main invariants of an affine connection are its torsion and its curvature. The torsion measures how closely the Lie bracket of vector fields can be recovered from the affine connection. Affine connections may also be used to define (affine) geodesics on a manifold, generalizing the straight lines of Euclidean space, although the geometry of those straight lines can be very different from usual Euclidean geometry; the main differences are encapsulated in the curvature of the connection.},
-  copyright = {Creative Commons Attribution-ShareAlike License},
-  langid = {english},
-  annotation = {Page Version ID: 1232389808},
-  file = {/Users/gonzalo/Zotero/storage/TJXJIJXP/Affine_connection.html}
-}
-
 @article{AprendizajeProfundo2025,
   title = {{Aprendizaje profundo}},
   year = 2025,
@@ -43,19 +9,6 @@
   langid = {spanish},
   annotation = {Page Version ID: 168943690},
   file = {/Users/gonzalo/Zotero/storage/UQJLN7EJ/index.html}
-}
-
-@article{Autoencoder2025,
-  title = {Autoencoder},
-  year = 2025,
-  month = aug,
-  journal = {Wikipedia},
-  urldate = {2025-09-13},
-  abstract = {An autoencoder is a type of artificial neural network used to learn efficient codings of unlabeled data (unsupervised learning). An autoencoder learns two functions: an encoding function that transforms the input data, and a decoding function that recreates the input data from the encoded representation. The autoencoder learns an efficient representation (encoding) for a set of data, typically for dimensionality reduction, to generate lower-dimensional embeddings for subsequent use by other machine learning algorithms. Variants exist which aim to make the learned representations assume useful properties. Examples are regularized autoencoders (sparse, denoising and contractive autoencoders), which are effective in learning representations for subsequent classification tasks, and variational autoencoders, which can be used as generative models. Autoencoders are applied to many problems, including facial recognition, feature detection, anomaly detection, and learning the meaning of words. In terms of data synthesis, autoencoders can also be used to randomly generate new data that is similar to the input (training) data.},
-  copyright = {Creative Commons Attribution-ShareAlike License},
-  langid = {english},
-  annotation = {Page Version ID: 1308725557},
-  file = {/Users/gonzalo/Zotero/storage/JB2TWNMU/index.html}
 }
 
 @misc{bengioConsciousnessPrior2019,
@@ -73,35 +26,6 @@
   langid = {english},
   keywords = {Computer Science - Artificial Intelligence,Computer Science - Machine Learning,Statistics - Machine Learning},
   file = {/Users/gonzalo/Zotero/storage/K4X43RFZ/Bengio - 2019 - The Consciousness Prior.pdf}
-}
-
-@inproceedings{bengioCurseHighlyVariable2005,
-  title = {The {{Curse}} of {{Highly Variable Functions}} for {{Local Kernel Machines}}},
-  booktitle = {Advances in {{Neural Information Processing Systems}}},
-  author = {Bengio, Yoshua and Delalleau, Olivier and Roux, Nicolas},
-  year = 2005,
-  volume = {18},
-  publisher = {MIT Press},
-  urldate = {2023-03-02},
-  abstract = {We present a series of theoretical arguments supporting the claim that a large class of modern learning algorithms that rely solely on the smoothness prior  with similarity between examples expressed with a local kernel  are sensitive to the curse of dimensionality, or more precisely to the variability of the target. Our discussion covers supervised, semisupervised and unsupervised learning algorithms. These algorithms are found to be local in the sense that crucial properties of the learned function at x depend mostly on the neighbors of x in the training set. This makes them sensitive to the curse of dimensionality, well studied for classical non-parametric statistical learning. We show in the case of the Gaussian kernel that when the function to be learned has many variations, these algorithms require a number of training examples proportional to the number of variations, which could be large even though there may exist short descriptions of the target function, i.e. their Kolmogorov complexity may be low. This suggests that there exist non-local learning algorithms that at least have the potential to learn about such structured but apparently complex functions (because locally they have many variations), while not using very specific prior domain knowledge.},
-  file = {/Users/gonzalo/Zotero/storage/NYEDLXTC/Bengio et al. - 2005 - The Curse of Highly Variable Functions for Local K.pdf}
-}
-
-@article{bengioLearningEigenfunctionsLinks2004,
-  title = {Learning {{Eigenfunctions Links Spectral Embedding}} and {{Kernel PCA}}},
-  author = {Bengio, Yoshua and Delalleau, Olivier and Roux, Nicolas Le and Paiement, Jean-Fran{\c c}ois and Vincent, Pascal and Ouimet, Marie},
-  year = 2004,
-  month = oct,
-  journal = {Neural Computation},
-  volume = {16},
-  number = {10},
-  pages = {2197--2219},
-  issn = {0899-7667, 1530-888X},
-  doi = {10.1162/0899766041732396},
-  urldate = {2023-03-02},
-  abstract = {In this paper, we show a direct relation between spectral embedding methods and kernel PCA, and how both are special cases of a more general learning problem, that of learning the principal eigenfunctions of an operator defined from a kernel and the unknown data generating density.},
-  langid = {english},
-  file = {/Users/gonzalo/Zotero/storage/G9QCDMAH/Bengio et al. - 2004 - Learning Eigenfunctions Links Spectral Embedding a.pdf}
 }
 
 @inproceedings{bengioNonLocalManifoldParzen2005,
@@ -175,38 +99,6 @@
   file = {/Users/gonzalo/Zotero/storage/AI8NAVDY/besse1978.pdf}
 }
 
-@inproceedings{beyerWhenNearestNeighbor1999,
-  title = {When Is "{{Nearest Neighbor}}" {{Meaningful}}?},
-  booktitle = {Database {{Theory}} - {{ICDT}}'99},
-  author = {Beyer, Kevin and Goldstein, Jonathan and Ramakrishnan, Raghu and Shaft, Uri},
-  editor = {Beeri, Catriel and Buneman, Peter},
-  year = 1999,
-  series = {Lecture {{Notes}} in {{Computer Science}}},
-  pages = {217--235},
-  publisher = {Springer},
-  address = {Berlin, Heidelberg},
-  doi = {10.1007/3-540-49257-7_15},
-  abstract = {We explore the effect of dimensionality on the ``nearest neighbor'' problem. We show that under a broad set of conditions (much broader than independent and identically distributed dimensions), as dimensionality increases, the distance to the nearest data point approaches the distance to the farthest data point. To provide a practical perspective, we present empirical results on both real and synthetic data sets that demonstrate that this effect can occur for as few as 10--15 dimensions.},
-  isbn = {978-3-540-49257-3},
-  langid = {english},
-  file = {/Users/gonzalo/Zotero/storage/VCFTVUSQ/Beyer et al. - 1999 - When Is “Nearest Neighbor” Meaningful.pdf}
-}
-
-@incollection{bickelLocalPolynomialRegression2007,
-  title = {Local Polynomial Regression on Unknown Manifolds},
-  booktitle = {Complex {{Datasets}} and {{Inverse Problems}}},
-  author = {Bickel, Peter J. and Li, Bo},
-  year = 2007,
-  month = jan,
-  volume = {54},
-  pages = {177--187},
-  publisher = {Institute of Mathematical Statistics},
-  doi = {10.1214/074921707000000148},
-  urldate = {2024-05-22},
-  abstract = {{$<$}!-- *** Custom HTML *** --{$><$}p{$>$}We reveal the phenomenon that ``naive'' multivariate local polynomial regression can adapt to local smooth lower dimensional structure in the sense that it achieves the optimal convergence rate for nonparametric estimation of regression functions belonging to a Sobolev space when the predictor variables live on or close to a lower dimensional manifold.{$<$}/p{$>$}},
-  file = {/Users/gonzalo/Zotero/storage/BHMP2WQY/Bickel and Li - 2007 - Local polynomial regression on unknown manifolds.pdf}
-}
-
 @misc{bijralSemisupervisedLearningDensity2012,
   title = {Semi-Supervised {{Learning}} with {{Density Based Distances}}},
   author = {Bijral, Avleen S. and Ratliff, Nathan and Srebro, Nathan},
@@ -272,32 +164,6 @@
   file = {/Users/gonzalo/Zotero/storage/QCQ7YXXR/Buitinck et al. - 2013 - API design for machine learning software experien.pdf;/Users/gonzalo/Zotero/storage/KBETFAYB/1309.html}
 }
 
-@article{calderHamiltonJacobiEquationsGraphs2022,
-  title = {Hamilton-{{Jacobi}} Equations on Graphs with Applications to Semi-Supervised Learning and Data Depth},
-  author = {Calder, Jeff and Ettehad, Mahmood},
-  year = 2022,
-  journal = {Journal of Machine Learning Research},
-  volume = {23},
-  number = {318},
-  pages = {1--62},
-  abstract = {Shortest path graph distances are widely used in data science and machine learning, since they can approximate the underlying geodesic distance on the data manifold. However, the shortest path distance is highly sensitive to the addition of corrupted edges in the graph, either through noise or an adversarial perturbation. In this paper we study a family of Hamilton-Jacobi equations on graphs that we call the p-eikonal equation. We show that the p-eikonal equation with p = 1 is a provably robust distance-type function on a graph, and the p {$\rightarrow$} {$\infty$} limit recovers shortest path distances. While the p-eikonal equation does not correspond to a shortest-path graph distance, we nonetheless show that the continuum limit of the p-eikonal equation on a random geometric graph recovers a geodesic density weighted distance in the continuum. We consider applications of the p-eikonal equation to data depth and semi-supervised learning, and use the continuum limit to prove asymptotic consistency results for both applications. Finally, we show the results of experiments with data depth and semi-supervised learning on real image datasets, including MNIST, FashionMNIST and CIFAR-10, which show that the p-eikonal equation offers significantly better results compared to shortest path distances.},
-  file = {/Users/gonzalo/Zotero/storage/8C8NGYJL/Calder and Ettehad - 2022 - Hamilton-Jacobi equations on graphs with applicati.pdf}
-}
-
-@techreport{carpioFingerprintsCancerPersistent2019,
-  type = {Preprint},
-  title = {Fingerprints of Cancer by Persistent Homology},
-  author = {Carpio, A. and Bonilla, L. L. and Mathews, J. C. and Tannenbaum, A. R.},
-  year = 2019,
-  month = sep,
-  institution = {Cancer Biology},
-  doi = {10.1101/777169},
-  urldate = {2023-03-02},
-  abstract = {We have carried out a topological data analysis of gene expressions for different databases based on the Fermat distance between the z scores of different tissue samples. There is a critical value of the filtration parameter at which all clusters collapse in a single one. This critical value for healthy samples is gapless and smaller than that for cancerous ones. After collapse in a single cluster, topological holes persist for larger filtration parameter values in cancerous samples. Barcodes, persistence diagrams and Betti numbers as functions of the filtration parameter are different for different types of cancer and constitute fingerprints thereof.},
-  langid = {english},
-  file = {/Users/gonzalo/Zotero/storage/8ZN8N9N9/Carpio et al. - 2019 - Fingerprints of cancer by persistent homology.pdf}
-}
-
 @article{caytonAlgorithmsManifoldLearning2005,
   title = {Algorithms for Manifold Learning},
   author = {Cayton, Lawrence},
@@ -305,58 +171,6 @@
   abstract = {Manifold learning is a popular recent approach to nonlinear dimensionality reduction. Algorithms for this task are based on the idea that the dimensionality of many data sets is only artificially high; though each data point consists of perhaps thousands of features, it may be described as a function of only a few underlying parameters. That is, the data points are actually samples from a low-dimensional manifold that is embedded in a high-dimensional space. Manifold learning algorithms attempt to uncover these parameters in order to find a low-dimensional representation of the data. In this paper, we discuss the motivation, background, and algorithms proposed for manifold learning. Isomap, Locally Linear Embedding, Laplacian Eigenmaps, Semidefinite Embedding, and a host of variants of these algorithms are examined.},
   langid = {english},
   file = {/Users/gonzalo/Zotero/storage/Q3RCYSTM/Cayton - Algorithms for manifold learning.pdf}
-}
-
-@article{chaconDatadrivenDensityDerivative2013,
-  title = {Data-Driven Density Derivative Estimation, with Applications to Nonparametric Clustering and Bump Hunting},
-  author = {Chac{\'o}n, Jos{\'e} E. and Duong, Tarn},
-  year = 2013,
-  month = jan,
-  journal = {Electron. J. Statist.},
-  volume = {7},
-  number = {none},
-  issn = {1935-7524},
-  doi = {10.1214/13-EJS781},
-  urldate = {2023-03-02},
-  abstract = {Important information concerning a multivariate data set, such as clusters and modal regions, is contained in the derivatives of the probability density function. Despite this importance, nonparametric estimation of higher order derivatives of the density functions have received only relatively scant attention. Kernel estimators of density functions are widely used as they exhibit excellent theoretical and practical properties, though their generalization to density derivatives has progressed more slowly due to the mathematical intractabilities encountered in the crucial problem of bandwidth (or smoothing parameter) selection. This paper presents the first fully automatic, data-based bandwidth selectors for multivariate kernel density derivative estimators. This is achieved by synthesizing recent advances in matrix analytic theory which allow mathematically and computationally tractable representations of higher order derivatives of multivariate vector valued functions. The theoretical asymptotic properties as well as the finite sample behaviour of the proposed selectors are studied. In addition, we explore in detail the applications of the new data-driven methods for two other statistical problems: clustering and bump hunting. The introduced techniques are combined with the mean shift algorithm to develop novel automatic, nonparametric clustering procedures which are shown to outperform mixture-model cluster analysis and other recent nonparametric approaches in practice. Furthermore, the advantage of the use of smoothing parameters designed for density derivative estimation for feature significance analysis for bump hunting is illustrated with a real data example.},
-  langid = {english},
-  file = {/Users/gonzalo/Zotero/storage/52VG4PRB/Chacón and Duong - 2013 - Data-driven density derivative estimation, with ap.pdf}
-}
-
-@book{chavelRiemannianGeometryModern2006,
-  title = {Riemannian Geometry: A Modern Introduction},
-  shorttitle = {Riemannian Geometry},
-  author = {Chavel, Isaac},
-  year = 2006,
-  series = {Cambridge Studies in Advanced Mathematics},
-  edition = {2nd ed},
-  number = {98},
-  publisher = {Cambridge University Press},
-  address = {New York},
-  isbn = {978-0-521-85368-2 978-0-521-61954-7},
-  langid = {english},
-  lccn = {QA649 .C45 2006},
-  keywords = {Geometry Riemannian},
-  annotation = {OCLC: ocm62089870},
-  file = {/Users/gonzalo/Zotero/storage/IVWATM2C/Chavel - 2006 - Riemannian geometry a modern introduction.pdf}
-}
-
-@misc{chenComprehensiveApproachMode2015,
-  title = {A {{Comprehensive Approach}} to {{Mode Clustering}}},
-  author = {Chen, Yen-Chi and Genovese, Christopher R. and Wasserman, Larry},
-  year = 2015,
-  month = dec,
-  number = {arXiv:1406.1780},
-  eprint = {1406.1780},
-  primaryclass = {stat},
-  publisher = {arXiv},
-  urldate = {2023-03-02},
-  abstract = {Mode clustering is a nonparametric method for clustering that defines clusters using the basins of attraction of a density estimator's modes. We provide several enhancements to mode clustering: (i) a soft variant of cluster assignment, (ii) a measure of connectivity between clusters, (iii) a technique for choosing the bandwidth, (iv) a method for denoising small clusters, and (v) an approach to visualizing the clusters. Combining all these enhancements gives us a complete procedure for clustering in multivariate problems. We also compare mode clustering to other clustering methods in several examples.},
-  archiveprefix = {arXiv},
-  langid = {english},
-  keywords = {62H30 (Primary) 62G07 62G99 (Secondary),Statistics - Machine Learning,Statistics - Methodology},
-  note = {Comment: 34 pages, 17 figures. Accepted to the Electronic Journal of Statistics. The original title is "Enhanced Mode Clustering"},
-  file = {/Users/gonzalo/Zotero/storage/2M3P8733/Chen et al. - 2015 - A Comprehensive Approach to Mode Clustering.pdf}
 }
 
 @inproceedings{chenXGBoostScalableTree2016,
@@ -390,30 +204,6 @@
   urldate = {2023-03-12},
   abstract = {Data-sensitive metrics adapt distances locally based the density of data points with the goal of aligning distances and some notion of similarity. In this paper, we give the first exact algorithm for computing a data-sensitive metric called the nearest neighbor metric. In fact, we prove the surprising result that a previously published 3-approximation is an exact algorithm. The nearest neighbor metric can be viewed as a special case of a density-based distance used in machine learning, or it can be seen as an example of a manifold metric. Previous computational research on such metrics despaired of computing exact distances on account of the apparent difficulty of minimizing over all continuous paths between a pair of points. We leverage the exact computation of the nearest neighbor metric to compute sparse spanners and persistent homology. We also explore the behavior of the metric built from point sets drawn from an underlying distribution and consider the more general case of inputs that are finite collections of path-connected compact sets. The main results connect several classical theories such as the conformal change of Riemannian metrics, the theory of positive definite functions of Schoenberg, and screw function theory of Schoenberg and Von Neumann. We also develop some novel proof techniques based on the combination of screw functions and Lipschitz extensions that may be of independent interest.},
   file = {/Users/gonzalo/Zotero/storage/PYHYGYEZ/Chu et al. - 2019 - Exact computation of a manifold metric, via Lipsch.pdf;/Users/gonzalo/Zotero/storage/YJVHNGZG/arXiv v3 - Exploration of a Graph-based Density-Sensitive Metric.pdf}
-}
-
-@misc{claudecoulombeWhoFirstAdvanced2021,
-  type = {Reddit {{Post}}},
-  title = {[{{D}}] {{Who}} First Advanced the "Manifold Hypothesis" to Explain the Stunning Generalization Capacity of Deep Learning?},
-  author = {ClaudeCoulombe},
-  year = 2021,
-  month = apr,
-  journal = {r/MachineLearning},
-  urldate = {2025-09-13},
-  file = {/Users/gonzalo/Zotero/storage/68VEZ93L/d_who_first_advanced_the_manifold_hypothesis_to.html}
-}
-
-@article{ConvergenceRandomVariables2025,
-  title = {Convergence of Random Variables},
-  year = 2025,
-  month = jul,
-  journal = {Wikipedia},
-  urldate = {2025-08-30},
-  abstract = {In probability theory, there exist several different notions of convergence of sequences of random variables, including convergence in probability, convergence in distribution, and almost sure convergence. The different notions of convergence capture different properties about the sequence, with some notions of convergence being stronger than others. For example, convergence in distribution tells us about the limit distribution of a sequence of random variables. This is a weaker notion than convergence in probability, which tells us about the value a random variable will take, rather than just the distribution. The concept is important in probability theory, and its applications to statistics and stochastic processes. The same concepts are known in more general mathematics as stochastic convergence and they formalize the idea that certain properties of a sequence of essentially random or unpredictable events can sometimes be expected to settle down into a behavior that is essentially unchanging when items far enough into the sequence are studied. The different possible notions of convergence relate to how such a behavior can be characterized: two readily understood behaviors are that the sequence eventually takes a constant value, and that values in the sequence continue to change but can be described by an unchanging probability distribution.},
-  copyright = {Creative Commons Attribution-ShareAlike License},
-  langid = {english},
-  annotation = {Page Version ID: 1299281217},
-  file = {/Users/gonzalo/Zotero/storage/XMSATG4K/Convergence_of_random_variables.html}
 }
 
 @article{cortesSupportvectorNetworks1995,
@@ -451,40 +241,6 @@
   file = {/Users/gonzalo/Zotero/storage/FAXPH8WR/Cox - 1958 - The Regression Analysis of Binary Sequences.pdf}
 }
 
-@article{Crossentropy2025,
-  title = {Cross-Entropy},
-  year = 2025,
-  month = jul,
-  journal = {Wikipedia},
-  urldate = {2025-09-01},
-  abstract = {In information theory, the cross-entropy between two probability distributions                         p                 \textbraceleft\textbackslash displaystyle p\textbraceright{}     and                         q                 \textbraceleft\textbackslash displaystyle q\textbraceright{}    , over the same underlying set of events, measures the average number of bits needed to identify an event drawn from the set when the coding scheme used for the set is optimized for an estimated probability distribution                         q                 \textbraceleft\textbackslash displaystyle q\textbraceright{}    , rather than the true distribution                         p                 \textbraceleft\textbackslash displaystyle p\textbraceright{}    .},
-  copyright = {Creative Commons Attribution-ShareAlike License},
-  langid = {english},
-  annotation = {Page Version ID: 1301968851},
-  file = {/Users/gonzalo/Zotero/storage/JPVMIYM8/Cross-entropy.html}
-}
-
-@misc{davenportBayesRuleRandom2014,
-  title = {Bayes Rule for Random Variables},
-  author = {Davenport, M. and Romberg, J. and Rozell, J},
-  year = 2014,
-  annotation = {ECE 3077 Notes by M. Davenport, J. Romberg and C. Rozell. Last updated 21:27, June 25, 2014},
-  file = {/Users/gonzalo/Zotero/storage/83NTKU79/16_BayesRVs-su14.pdf}
-}
-
-@article{DeepLearning2025,
-  title = {Deep Learning},
-  year = 2025,
-  month = sep,
-  journal = {Wikipedia},
-  urldate = {2025-09-13},
-  abstract = {In machine learning, deep learning focuses on utilizing multilayered neural networks to perform tasks such as classification, regression, and representation learning. The field takes inspiration from biological neuroscience and is centered around stacking artificial neurons into layers and "training" them to process data. The adjective "deep" refers to the use of multiple layers (ranging from three to several hundred or thousands) in the network. Methods used can be supervised, semi-supervised or unsupervised. Some common deep learning network architectures include fully connected networks, deep belief networks, recurrent neural networks, convolutional neural networks, generative adversarial networks, transformers, and neural radiance fields. These architectures have been applied to fields including computer vision, speech recognition, natural language processing, machine translation, bioinformatics, drug design, medical image analysis, climate science, material inspection and board game programs, where they have produced results comparable to and in some cases surpassing human expert performance. Early forms of neural networks were inspired by information processing and distributed communication nodes in biological systems, particularly the human brain. However, current neural networks do not intend to model the brain function of organisms, and are generally seen as low-quality models for that purpose.},
-  copyright = {Creative Commons Attribution-ShareAlike License},
-  langid = {english},
-  annotation = {Page Version ID: 1309250536},
-  file = {/Users/gonzalo/Zotero/storage/94EDMRN4/index.html}
-}
-
 @book{devroyeProbabilisticTheoryPattern1996,
   title = {A Probabilistic Theory of Pattern Recognition},
   author = {Devroye, Luc and Gy{\"o}rfi, L{\'a}szl{\'o} and Lugosi, G{\'a}bor},
@@ -500,19 +256,6 @@
   file = {/Users/gonzalo/Zotero/storage/AFEZXQ7W/Devroye et al. - 1996 - A probabilistic theory of pattern recognition.pdf}
 }
 
-@article{DistanciaMahalanobis2024,
-  title = {{Distancia de Mahalanobis}},
-  year = 2024,
-  month = jan,
-  journal = {Wikipedia, la enciclopedia libre},
-  urldate = {2026-01-26},
-  abstract = {En estad\'istica, la distancia de Mahalanobis es una medida de distancia introducida por Mahalanobis en 1936. Su utilidad radica en que es una forma de determinar la similitud entre dos variables aleatorias multidimensionales. Se diferencia de la distancia eucl\'idea en que tiene en cuenta la correlaci\'on entre las variables aleatorias. Formalmente, la distancia de Mahalanobis entre dos variables aleatorias con la misma distribuci\'on de probabilidad                                                                x               {$\rightarrow$}                                                  \textbraceleft\textbackslash displaystyle \textbraceleft\textbackslash vec \textbraceleft x\textbraceright\textbraceright\textbraceright{}     y                                                                y               {$\rightarrow$}                                                  \textbraceleft\textbackslash displaystyle \textbraceleft\textbackslash vec \textbraceleft y\textbraceright\textbraceright\textbraceright{}     con matriz de covarianza                         {$\Sigma$}                 \textbraceleft\textbackslash displaystyle \textbackslash Sigma \textbraceright{}     se define como:                                   d                        m                             (                                                x               {$\rightarrow$}                                          ,                                                y               {$\rightarrow$}                                          )         =                                 (                                                                x                   {$\rightarrow$}                                                          -                                                                y                   {$\rightarrow$}                                                                         )                                T                                                        {$\Sigma$}                                -                 1                                         (                                                                x                   {$\rightarrow$}                                                          -                                                                y                   {$\rightarrow$}                                                          )                             .                          \textbraceleft\textbackslash displaystyle d\_\textbraceleft m\textbraceright (\textbraceleft\textbackslash vec \textbraceleft x\textbraceright\textbraceright,\textbraceleft\textbackslash vec \textbraceleft y\textbraceright\textbraceright )=\textbraceleft\textbackslash sqrt \textbraceleft (\textbraceleft\textbackslash vec \textbraceleft x\textbraceright\textbraceright -\textbraceleft\textbackslash vec \textbraceleft y\textbraceright\textbraceright )\textasciicircum\textbraceleft T\textbraceright\textbackslash Sigma \textasciicircum\textbraceleft -1\textbraceright (\textbraceleft\textbackslash vec \textbraceleft x\textbraceright\textbraceright -\textbraceleft\textbackslash vec \textbraceleft y\textbraceright\textbraceright )\textbraceright\textbraceright.\textbackslash,\textbraceright},
-  copyright = {Creative Commons Attribution-ShareAlike License},
-  langid = {spanish},
-  annotation = {Page Version ID: 157155023},
-  file = {/Users/gonzalo/Zotero/storage/NPCH62LP/index.html}
-}
-
 @book{docarmoRiemannianGeometry1992,
   title = {Riemannian {{Geometry}}},
   author = {{do Carmo}, Manfredo P.},
@@ -524,70 +267,6 @@
   langid = {english},
   keywords = {Mathematics / Geometry / Analytic,Mathematics / Geometry / Differential,Mathematics / Geometry / General,Mathematics / Geometry / Non-Euclidean,Science / General,Science / Physics / General,Science / Physics / Mathematical & Computational},
   file = {/Users/gonzalo/Zotero/storage/VJE28XKV/do Carmo - 1992 - Riemannian Geometry.pdf}
-}
-
-@misc{DocumentZbl075253001,
-  title = {Document {{Zbl}} 0752.53001 - {{zbMATH Open}}},
-  urldate = {2025-08-26},
-  howpublished = {https://zbmath.org/?format=complete\&q=an:0752.53001}
-}
-
-@article{duongCrossvalidationBandwidthMatrices2005,
-  title = {Cross-Validation {{Bandwidth Matrices}} for {{Multivariate Kernel Density Estimation}}},
-  author = {Duong, Tarn and Hazelton, Martin L.},
-  year = 2005,
-  month = sep,
-  journal = {Scand J Stat},
-  volume = {32},
-  number = {3},
-  pages = {485--506},
-  issn = {0303-6898, 1467-9469},
-  doi = {10.1111/j.1467-9469.2005.00445.x},
-  urldate = {2023-03-02},
-  abstract = {The performance of multivariate kernel density estimates depends crucially on the choice of bandwidth matrix, but progress towards developing good bandwidth matrix selectors has been relatively slow. In particular, previous studies of cross-validation (CV) methods have been restricted to biased and unbiased CV selection of diagonal bandwidth matrices. However, for certain types of target density the use of full (i.e. unconstrained) bandwidth matrices offers the potential for significantly improved density estimation. In this paper, we generalize earlier work from diagonal to full bandwidth matrices, and develop a smooth cross-validation (SCV) methodology for multivariate data. We consider optimization of the SCV technique with respect to a pilot bandwidth matrix. All the CV methods are studied using asymptotic analysis, simulation experiments and real data analysis. The results suggest that SCV for full bandwidth matrices is the most reliable of the CV methods. We also observe that experience from the univariate setting can sometimes be a misleading guide for understanding bandwidth selection in the multivariate case.},
-  langid = {english},
-  file = {/Users/gonzalo/Zotero/storage/SNZ4M2YX/Duong and Hazelton - 2005 - Cross-validation Bandwidth Matrices for Multivaria.pdf}
-}
-
-@article{EntornoMatematica2024,
-  title = {{Entorno (matem\'atica)}},
-  year = 2024,
-  month = jul,
-  journal = {Wikipedia, la enciclopedia libre},
-  urldate = {2025-08-25},
-  abstract = {Un entorno (o vecindad)\hspace{0pt} es uno de los conceptos b\'asicos de la   topolog\'ia. Adem\'as, este concepto se utiliza en muchas otras \'areas de las matem\'aticas como el an\'alisis y la teor\'ia de la probabilidad. Intuitivamente hablando, un entorno de un punto es un conjunto que contiene al punto y a un conjunto de los puntos m\'as pr\'oximos a \'el. El aspecto geogr\'afico de vecindad en un lugar se refleja en este concepto matem\'atico. El concepto de entorno est\'a estrechamente relacionado con los conceptos de conjunto abierto y punto interior.},
-  copyright = {Creative Commons Attribution-ShareAlike License},
-  langid = {spanish},
-  annotation = {Page Version ID: 161262959},
-  file = {/Users/gonzalo/Zotero/storage/TT6M6HV4/Entorno_(matemática).html}
-}
-
-@article{federerCurvatureMeasures1959,
-  title = {Curvature {{Measures}}},
-  author = {Federer, Herbert},
-  year = 1959,
-  journal = {Transactions of the American Mathematical Society},
-  volume = {93},
-  number = {3},
-  eprint = {1993504},
-  eprinttype = {jstor},
-  pages = {418--491},
-  publisher = {American Mathematical Society},
-  issn = {0002-9947},
-  doi = {10.2307/1993504},
-  urldate = {2024-05-22},
-  file = {/Users/gonzalo/Zotero/storage/63ZCIYFP/Federer - 1959 - Curvature Measures.pdf}
-}
-
-@book{fisherDesignExperiments1935,
-  title = {{The Design Of Experiments}},
-  author = {a Fisher, R.},
-  year = 1935,
-  urldate = {2023-04-24},
-  abstract = {Book Source: Digital Library of India Item 2015.502684 dc.contributor.author: Fisher, R.a. dc.date.accessioned: 2015-09-26T03:23:45Z dc.date.available: 2015-09-26T03:23:45Z dc.date.copyright: 1935 dc.date.digitalpublicationdate: 2005/07/4 dc.date.citation: 1935 dc.identifier.barcode: 04990010257068 dc.identifier.origpath: /data4/upload/0109/780 dc.identifier.copyno: 1 dc.identifier.uri: http://www.new.dli.ernet.in/handle/2015/502684 dc.description.scannerno: RMSC/CDAC/KOL/017 dc.description.scanningcentre: C-DAK, Kolkata dc.description.main: 1 dc.description.tagged: 0 dc.description.totalpages: 274 dc.format.mimetype: application/pdf dc.language.iso: Unknown dc.publisher.digitalrepublisher: Digital Library Of India dc.publisher: Oliver And Boyd, London dc.source.library: Tra Library, Jorhat dc.subject.classification: Technology dc.subject.classification: Agriculture And Related Sciences And Techniques. Forestry. Farming. Wildlife Exploitation dc.subject.classification: Agricultural Experiments dc.subject.keywords: Statistical Methods dc.subject.keywords: Psycho-Physical Experiments dc.subject.keywords: Probability dc.title: The Design Of Experiments dc.type: Print - Paper dc.type: Book},
-  langid = {Unknown},
-  keywords = {C-DAK,prob y est},
-  file = {/Users/gonzalo/Zotero/storage/S38ZJKHS/Fisher - 1935 - The Design Of Experiments.pdf}
 }
 
 @article{fisherDispersionSphere1957,
@@ -641,33 +320,6 @@
   file = {/Users/gonzalo/Zotero/storage/IY2LNTND/Friedman - 2001 - Greedy function approximation A gradient boosting machine..pdf}
 }
 
-@book{fukunagaIntroductionStatisticalPattern2013,
-  title = {Introduction to {{Statistical Pattern Recognition}}},
-  author = {Fukunaga, Keinosuke},
-  year = 2013,
-  month = oct,
-  publisher = {Elsevier},
-  abstract = {This completely revised second edition presents an introduction to statistical pattern recognition. Pattern recognition in general covers a wide range of problems: it is applied to engineering problems, such as character readers and wave form analysis as well as to brain modeling in biology and psychology. Statistical decision and estimation, which are the main subjects of this book, are regarded as fundamental to the study of pattern recognition. This book is appropriate as a text for introductory courses in pattern recognition and as a reference book for workers in the field. Each chapter contains computer projects as well as exercises.},
-  googlebooks = {BIJZTGjTxBgC},
-  isbn = {978-0-08-047865-4},
-  langid = {english},
-  keywords = {Computers / Artificial Intelligence / Computer Vision & Pattern Recognition},
-  file = {/Users/gonzalo/Zotero/storage/TMT4IZRS/Fukunaga - Introduction to Statistical Pattern Recognition Second Edition.pdf}
-}
-
-@article{FunctionMathematics2025,
-  title = {Function (Mathematics)},
-  year = 2025,
-  month = aug,
-  journal = {Wikipedia},
-  urldate = {2025-08-28},
-  abstract = {In mathematics, a function from a set X to a set Y assigns to each element of X exactly one element of Y. The set X is called the domain of the function and the set Y is called the codomain of the function. Functions were originally the idealization of how a varying quantity depends on another quantity. For example, the position of a planet is a function of time. Historically, the concept was elaborated with the infinitesimal calculus at the end of the 17th century, and, until the 19th century, the functions that were considered were differentiable (that is, they had a high degree of regularity). The concept of a function was formalized at the end of the 19th century in terms of set theory, and this greatly increased the possible applications of the concept. A function is often denoted by a letter such as f, g or h. The value of a function f at an element x of its domain (that is, the element of the codomain that is associated with x) is denoted by f(x); for example, the value of f at x = 4 is denoted by f(4). Commonly, a specific function is defined by means of an expression depending on x, such as                         f         (         x         )         =                    x                        2                             +         1         ;                 \textbraceleft\textbackslash displaystyle f(x)=x\textasciicircum\textbraceleft 2\textbraceright +1;\textbraceright{}     in this case, some computation, called function evaluation, may be needed for deducing the value of the function at a particular value; for example, if                         f         (         x         )         =                    x                        2                             +         1         ,                 \textbraceleft\textbackslash displaystyle f(x)=x\textasciicircum\textbraceleft 2\textbraceright +1,\textbraceright{}     then                         f         (         4         )         =                    4                        2                             +         1         =         17.                 \textbraceleft\textbackslash displaystyle f(4)=4\textasciicircum\textbraceleft 2\textbraceright +1=17.\textbraceright{}    Given its domain and its codomain, a function is uniquely represented by the set of all pairs (x, f{$\mkern1mu$}(x)), called the graph of the function, a popular means of illustrating the function. When the domain and the codomain are sets of real numbers, each such pair may be thought of as the Cartesian coordinates of a point in the plane. Functions are widely used in science, engineering, and in most fields of mathematics. It has been said that functions are "the central objects of investigation" in most fields of mathematics. The concept of a function has evolved significantly over centuries, from its informal origins in ancient mathematics to its formalization in the 19th century. See History of the function concept for details.},
-  copyright = {Creative Commons Attribution-ShareAlike License},
-  langid = {english},
-  annotation = {Page Version ID: 1304243708},
-  file = {/Users/gonzalo/Zotero/storage/YBMV7QBJ/Function_(mathematics).html}
-}
-
 @article{galleseRootsEmpathyShared2003,
   title = {The {{Roots}} of {{Empathy}}: {{The Shared Manifold Hypothesis}} and the {{Neural Basis}} of {{Intersubjectivity}}},
   shorttitle = {The {{Roots}} of {{Empathy}}},
@@ -683,46 +335,6 @@
   urldate = {2025-08-11},
   abstract = {Starting from a neurobiological standpoint, I will propose that our capacity to understand others as intentional agents, far from being exclusively dependent upon mentalistic/linguistic abilities, be deeply grounded in the relational nature of our interactions with the world. According to this hypothesis, an implicit, prereflexive form of understanding of other individuals is based on the strong sense of identity binding us to them. We share with our conspecifics a multiplicity of states that include actions, sensations and emotions. A new conceptual tool able to capture the richness of the experiences we share with others will be introduced: the shared manifold of intersubjectivity. I will posit that it is through this shared manifold that it is possible for us to recognize other human beings as similar to us. It is just because of this shared manifold that intersubjective communication and ascription of intentionality become possible. It will be argued that the same neural structures that are involved in processing and controlling executed actions, felt sensations and emotions are also active when the same actions, sensations and emotions are to be detected in others. It therefore appears that a whole range of different `mirror matching mechanisms' may be present in our brain. This matching mechanism, constituted by mirror neurons originally discovered and described in the domain of action, could well be a basic organizational feature of our brain, enabling our rich and diversified intersubjective experiences. This perspective is in a position to offer a global approach to the understanding of the vulnerability to major psychoses such as schizophrenia.},
   file = {/Users/gonzalo/Zotero/storage/5HQ3AC89/The-Roots-of-Empathy-The-Shared-Manifold.html}
-}
-
-@book{gallotRiemannianGeometry2004,
-  title = {Riemannian {{Geometry}}},
-  author = {Gallot, Sylvestre and Hulin, Dominique and Lafontaine, Jacques},
-  year = 2004,
-  series = {Universitext},
-  publisher = {Springer},
-  address = {Berlin, Heidelberg},
-  doi = {10.1007/978-3-642-18855-8},
-  urldate = {2024-05-23},
-  copyright = {http://www.springer.com/tdm},
-  isbn = {978-3-540-20493-0 978-3-642-18855-8},
-  keywords = {covariant derivative,curvature,manifold,Minimal surface,relativity,Riemannian geometry,Riemannian goemetry},
-  file = {/Users/gonzalo/Zotero/storage/4NY4SNFZ/Gallot et al. - 2004 - Riemannian Geometry.pdf}
-}
-
-@book{garcia-portuguesShortCourseNonparametric2022,
-  title = {A {{Short Course}} on {{Nonparametric Curve Estimation}}},
-  author = {{Garc{\'i}a-Portugu{\'e}s}, Eduardo},
-  year = 2022,
-  month = apr,
-  urldate = {2023-03-08},
-  abstract = {A Short Course on Nonparametric Curve Estimation. MSc in Applied Mathematics. EAFIT University (Colombia).},
-  annotation = {Last updated: 2022-04-26, v2.1.1},
-  note = {\textbackslash href\textbraceleft https://bookdown.org/egarpor/NP-EAFIT/\textbraceright\textbraceleft\S\textbraceright{}},
-  file = {/Users/gonzalo/Zotero/storage/U7DYZWK4/NP-EAFIT.html}
-}
-
-@article{GradientBoosting2025,
-  title = {{Gradient boosting}},
-  year = 2025,
-  month = feb,
-  journal = {Wikipedia, la enciclopedia libre},
-  urldate = {2026-01-26},
-  abstract = {Gradient boosting o potenciaci\'on del gradiente, es una t\'ecnica de aprendizaje autom\'atico utilizado para el an\'alisis de la regresi\'on y para problemas de clasificaci\'on estad\'istica, el cual produce un modelo predictivo en forma de un conjunto de modelos de predicci\'on d\'ebiles, t\'ipicamente \'arboles de decisi\'on. Construye el modelo de forma escalonada como lo hacen otros m\'etodos de boosting, y los generaliza permitiendo la optimizaci\'on arbitraria de una funci\'on de p\'erdida diferenciable. La idea de la potenciaci\'on del gradiente fue originada en la observaci\'on realizada por Leo Breiman\hspace{0pt} en donde el Boosting puede ser interpretado como un algoritmo de optimizaci\'on en una funci\'on de coste adecuada. Posteriormente Jerome H. Friedman\hspace{0pt}\hspace{0pt} desarroll\'o algoritmos de aumento de gradiente de regresi\'on expl\'icita, simult\'aneamente con la perspectiva m\'as general de potenciaci\'on del gradiente funcional de Llew Mason, Jonathan Baxter, Peter Bartlett y Marcus Frean.\hspace{0pt}\hspace{0pt} En sus \'ultimos dos trabajos presentaron la visi\'on abstracta de los algoritmos de potenciaci\'on como algoritmos iterativos de descenso de gradientes funcionales. Es decir, algoritmos que optimizan una funci\'on de coste sobre el espacio de funci\'on mediante la elecci\'on iterativa de una funci\'on (hip\'otesis d\'ebil) que apunta en la direcci\'on del gradiente negativo. Esta visi\'on de gradiente funcional de potenciaci\'on ha llevado al desarrollo de algoritmos de potenciaci\'on en muchas \'areas del aprendizaje autom\'atico y estad\'isticas m\'as all\'a de la regresi\'on y la clasificaci\'on. Una caracter\'istica distintiva del Potenciaci\'on del Gradiente es su capacidad para manejar diferentes tipos de funciones de p\'erdida, lo que le permite ser adaptable a una variedad de problemas estad\'isticos y de aprendizaje autom\'atico. Adem\'as, la t\'ecnica emplea m\'etodos como el "shrinkage" (reducci\'on de la tasa de aprendizaje) y la potenciaci\'on estoc\'astica para mejorar la precisi\'on y prevenir el sobreajuste.\hspace{0pt}},
-  copyright = {Creative Commons Attribution-ShareAlike License},
-  langid = {spanish},
-  annotation = {Page Version ID: 165271631},
-  file = {/Users/gonzalo/Zotero/storage/G789ZQMY/index.html}
 }
 
 @misc{groismanNonhomogeneousEuclideanFirstpassage2019,
@@ -785,37 +397,6 @@
   file = {/Users/gonzalo/Zotero/storage/CUVPHEPW/Henry and Rodriguez - 2009 - Kernel Density Estimation on Riemannian Manifolds.pdf}
 }
 
-@article{huberProjectionPursuit1985,
-  title = {Projection {{Pursuit}}},
-  author = {Huber, Peter J.},
-  year = 1985,
-  journal = {The Annals of Statistics},
-  volume = {13},
-  number = {2},
-  eprint = {2241175},
-  eprinttype = {jstor},
-  pages = {435--475},
-  langid = {english},
-  file = {/Users/gonzalo/Zotero/storage/8FGJUMHJ/Huber - 1985 - Projection Pursuit.pdf}
-}
-
-@article{jenq-nenghwangNonparametricMultivariateDensity1994,
-  title = {Nonparametric Multivariate Density Estimation: A Comparative Study},
-  shorttitle = {Nonparametric Multivariate Density Estimation},
-  author = {{Jenq-Neng Hwang} and {Shyh-Rong Lay} and Lippman, A.},
-  year = 1994,
-  journal = {IEEE Trans. Signal Process.},
-  volume = {42},
-  number = {10},
-  pages = {2795--2810},
-  issn = {1053587X},
-  doi = {10.1109/78.324744},
-  urldate = {2023-03-02},
-  abstract = {This paper algorithmically and empirically studies two major types of nonparametricmultivariatedensity estimation techniques, where no assumption is made about the data being drawn from any of known parametric families of distribution. The first type is the popular kernel method (and several of its variants) which uses locally tuned radial basis (e.g., Gaussian) functions to interpolate the multidimensional density; the second type is based on an exploratory projection pursuit technique which interprets the multidimensionaldensity through the construction of several 1-D densities along highly ``interesting'' projections of multidimensional data. Performance evaluations using training data from mixture Gaussian and mixture Cauchy densities are presented. The results show that the curse of dimensionality and the sensitivity of control parameters have a much more adverse impact on the kernel density estimators than on the projection pursuit density estimators.},
-  langid = {english},
-  file = {/Users/gonzalo/Zotero/storage/8MBX5UI9/Jenq-Neng Hwang et al. - 1994 - Nonparametric multivariate density estimation a c.pdf}
-}
-
 @article{JMLR:v12:pedregosa11a,
   title = {Scikit-Learn: {{Machine}} Learning in Python},
   author = {Pedregosa, Fabian and Varoquaux, Ga{\"e}l and Gramfort, Alexandre and Michel, Vincent and Thirion, Bertrand and Grisel, Olivier and Blondel, Mathieu and Prettenhofer, Peter and Weiss, Ron and Dubourg, Vincent and Vanderplas, Jake and Passos, Alexandre and Cournapeau, David and Brucher, Matthieu and Perrot, Matthieu and Duchesnay, {\'E}douard},
@@ -856,77 +437,6 @@
   file = {/Users/gonzalo/Zotero/storage/M9W8RB56/Ke et al. - 2017 - LightGBM A Highly Efficient Gradient Boosting Decision Tree.pdf}
 }
 
-@misc{KillersSomebodyTold,
-  title = {The {{Killers}} -- {{Somebody Told Me}}},
-  urldate = {2025-09-24},
-  abstract = {``Somebody Told Me'' is the second single by American rock band The Killers. The song is featured on the group's debut album Hot Fuss and was written by Dave Keuning, Ronnie Vannucci},
-  file = {/Users/gonzalo/Zotero/storage/37IK7LI6/The-killers-somebody-told-me-lyrics.html}
-}
-
-@book{kohonenSelfOrganizationAssociativeMemory1988,
-  title = {Self-{{Organization}} and {{Associative Memory}}},
-  author = {Kohonen, Teuvo},
-  editor = {Huang, Thomas S. and Schroeder, Manfred R.},
-  year = 1988,
-  series = {Springer {{Series}} in {{Information Sciences}}},
-  volume = {8},
-  publisher = {Springer Berlin Heidelberg},
-  address = {Berlin, Heidelberg},
-  doi = {10.1007/978-3-662-00784-6},
-  urldate = {2025-08-11},
-  copyright = {http://www.springer.com/tdm},
-  isbn = {978-3-540-18314-3 978-3-662-00784-6}
-}
-
-@article{kohonenSelforganizedFormationTopologically1982,
-  title = {Self-Organized Formation of Topologically Correct Feature Maps},
-  author = {Kohonen, Teuvo},
-  year = 1982,
-  journal = {Biol. Cybern.},
-  volume = {43},
-  number = {1},
-  pages = {59--69},
-  issn = {0340-1200, 1432-0770},
-  doi = {10.1007/BF00337288},
-  urldate = {2025-08-11},
-  abstract = {This work contains a theoretical study and computer simulations of a new self-organizing process. The principal discovery is that in a simple network of adaptive physical elements which receives signals from a primary event space, the signal representations are automatically mapped onto a set of output responses in such a way that the responses acquire the same topological order as that of the primary events. In other words, a principle has been discovered which facilitates the automatic formation of topologically correct maps of features of observable events. The basic self-organizing system is a one- or twodimensional array of processing units resembling a network of threshold-logic units, and characterized by short-range lateral feedback between neighbouring units. Several types of computer simulations are used to demonstrate the ordering process as well as the conditions under which it fails.},
-  copyright = {http://www.springer.com/tdm},
-  langid = {english},
-  file = {/Users/gonzalo/Zotero/storage/URGWFBBT/Kohonen - 1982 - Self-organized formation of topologically correct .pdf}
-}
-
-@article{kokluMulticlassClassificationDry2020,
-  title = {Multiclass Classification of Dry Beans Using Computer Vision and Machine Learning Techniques},
-  author = {Koklu, Murat and Ozkan, Ilker Ali},
-  year = 2020,
-  month = jul,
-  journal = {Computers and Electronics in Agriculture},
-  volume = {174},
-  pages = {105507},
-  issn = {01681699},
-  doi = {10.1016/j.compag.2020.105507},
-  urldate = {2024-05-28},
-  abstract = {Semantic Scholar extracted view of "Multiclass classification of dry beans using computer vision and machine learning techniques" by M. Koklu et al.},
-  langid = {english}
-}
-
-@article{korolyukAsymptoticTheoryUstatistics1988,
-  title = {Asymptotic Theory of {{U-statistics}}},
-  author = {Korolyuk, V. S. and Borovskikh, {\relax Yu}. V.},
-  year = 1988,
-  month = mar,
-  journal = {Ukr Math J},
-  volume = {40},
-  number = {2},
-  pages = {142--154},
-  issn = {1573-9376},
-  doi = {10.1007/BF01056469},
-  urldate = {2023-03-05},
-  langid = {english},
-  keywords = {Asymptotic Theory},
-  file = {/Users/gonzalo/Zotero/storage/TQJDTLYC/Korolyuk and Borovskikh - 1988 - Asymptotic theory of U-statistics.pdf}
-}
-
 @book{leeIntroductionRiemannianManifolds2018,
   title = {Introduction to {{Riemannian Manifolds}}},
   author = {Lee, John M.},
@@ -941,54 +451,6 @@
   isbn = {978-3-319-91754-2 978-3-319-91755-9},
   langid = {english},
   file = {/Users/gonzalo/Zotero/storage/EIBRMFG4/Lee - 2018 - Introduction to Riemannian Manifolds.pdf}
-}
-
-@article{levinaMaximumLikelihoodEstimation,
-  title = {Maximum {{Likelihood Estimation}} of {{Intrinsic Dimension}}},
-  author = {Levina, Elizaveta and Bickel, Peter J},
-  abstract = {We propose a new method for estimating intrinsic dimension of a dataset derived by applying the principle of maximum likelihood to the distances between close neighbors. We derive the estimator by a Poisson process approximation, assess its bias and variance theoretically and by simulations, and apply it to a number of simulated and real datasets. We also show it has the best overall performance compared with two other intrinsic dimension estimators.},
-  langid = {english},
-  file = {/Users/gonzalo/Zotero/storage/75YD5V98/Levina and Bickel - Maximum Likelihood Estimation of Intrinsic Dimensi.pdf}
-}
-
-@inproceedings{levinaMaximumLikelihoodEstimation2004,
-  title = {Maximum {{Likelihood Estimation}} of {{Intrinsic Dimension}}},
-  booktitle = {Advances in {{Neural Information Processing Systems}}},
-  author = {Levina, Elizaveta and Bickel, Peter},
-  year = 2004,
-  volume = {17},
-  publisher = {MIT Press},
-  urldate = {2024-05-23},
-  abstract = {We propose a new method for estimating intrinsic dimension of a dataset derived by applying the principle of maximum likelihood to the distances between close neighbors. We derive the estimator by a Poisson process approximation, assess its bias and variance theo- retically and by simulations, and apply it to a number of simulated and real datasets. We also show it has the best overall performance compared with two other intrinsic dimension estimators.},
-  file = {/Users/gonzalo/Zotero/storage/CAV9XVXL/Levina and Bickel - 2004 - Maximum Likelihood Estimation of Intrinsic Dimensi.pdf}
-}
-
-@article{LinearDiscriminantAnalysis2022,
-  title = {Linear Discriminant Analysis},
-  year = 2022,
-  month = dec,
-  journal = {Wikipedia},
-  urldate = {2023-03-03},
-  abstract = {Linear discriminant analysis (LDA), normal discriminant analysis (NDA), or discriminant function analysis is a generalization of Fisher's linear discriminant, a method used in statistics and other fields, to find a linear combination of features that characterizes or separates two or more classes of objects or events. The resulting combination may be used as a linear classifier, or, more commonly, for dimensionality reduction before later classification. LDA is closely related to analysis of variance (ANOVA) and regression analysis, which also attempt to express one dependent variable as a linear combination of other features or measurements. However, ANOVA uses categorical independent variables and a continuous dependent variable, whereas discriminant analysis has continuous independent variables and a categorical dependent variable (i.e. the class label). Logistic regression and probit regression are more similar to LDA than ANOVA is, as they also explain a categorical variable by the values of continuous independent variables. These other methods are preferable in applications where it is not reasonable to assume that the independent variables are normally distributed, which is a fundamental assumption of the LDA method. LDA is also closely related to principal component analysis (PCA) and factor analysis in that they both look for linear combinations of variables which best explain the data. LDA explicitly attempts to model the difference between the classes of data. PCA, in contrast, does not take into account any difference in class, and factor analysis builds the feature combinations based on differences rather than similarities. Discriminant analysis is also different from factor analysis in that it is not an interdependence technique: a distinction between independent variables and dependent variables (also called criterion variables) must be made. LDA works when the measurements made on independent variables for each observation are continuous quantities. When dealing with categorical independent variables, the equivalent technique is discriminant correspondence analysis.Discriminant analysis is used when groups are known a priori (unlike in cluster analysis). Each case must have a score on one or more quantitative predictor measures, and a score on a group measure. In simple terms, discriminant function analysis is classification - the act of distributing things into groups, classes or categories of the same type.},
-  copyright = {Creative Commons Attribution-ShareAlike License},
-  langid = {english},
-  annotation = {Page Version ID: 1130599337},
-  file = {/Users/gonzalo/Zotero/storage/YRFULRH6/Linear_discriminant_analysis.html}
-}
-
-@article{linShellTheoryStatistical2021,
-  title = {Shell {{Theory}}: {{A Statistical Model}} of {{Reality}}},
-  shorttitle = {Shell {{Theory}}},
-  author = {Lin, Wen-Yan and Liu, Siying and Ren, Changhao and Cheung, Ngai-Man and Li, Hongdong and Matsushita, Yasuyuki},
-  year = 2021,
-  journal = {IEEE Trans. Pattern Anal. Mach. Intell.},
-  pages = {1--1},
-  issn = {0162-8828, 2160-9292, 1939-3539},
-  doi = {10.1109/TPAMI.2021.3084598},
-  urldate = {2023-03-02},
-  abstract = {The foundational assumption of machine learning is that the data under consideration is separable into classes; while intuitively reasonable, separability constraints have proven remarkably difficult to formulate mathematically. We believe this problem is rooted in the mismatch between existing statistical techniques and commonly encountered data; object representations are typically high dimensional but statistical techniques tend to treat high dimensions a degenerate case. To address this problem, we develop a dedicated statistical framework for machine learning in high dimensions. The framework derives from the observation that object relations form a natural hierarchy; this leads us to model objects as instances of a high dimensional, hierarchal generative processes. Using a distance based statistical technique, also developed in this paper, we show that in such generative processes, instances of each process in the hierarchy, are almost-always encapsulated by a distinctive-shell that excludes almost-all other instances. The result is shell theory, a statistical machine learning framework in which separability constraints (distinctive-shells) are formally derived from the assumed generative process.},
-  langid = {english},
-  file = {/Users/gonzalo/Zotero/storage/3L999SHM/Lin et al. - 2021 - Shell Theory A Statistical Model of Reality.pdf}
 }
 
 @misc{littleBalancingGeometryDensity2021,
@@ -1024,19 +486,6 @@
   abstract = {Let X be a random variable taking values in a compact Riemannian manifold without boundary, and let Y be a discrete random variable valued in \textbraceleft 0; 1\textbraceright{} which represents a classification label. We introduce a kernel rule for classification on the manifold based on n independent copies of (X, Y ). Under mild assumptions on the bandwidth sequence, it is shown that this kernel rule is consistent in the sense that its probability of error converges to the Bayes risk with probability one.},
   langid = {english},
   file = {/Users/gonzalo/Zotero/storage/QLSVS3PR/Loubes and Pelletier - 2008 - A kernel-based classifier on a Riemannian manifold.pdf}
-}
-
-@article{MaquinaVectoresSoporte2025,
-  title = {{M\'aquina de vectores de soporte}},
-  year = 2025,
-  month = apr,
-  journal = {Wikipedia, la enciclopedia libre},
-  urldate = {2026-02-09},
-  abstract = {Las m\'aquinas de vectores de soporte o m\'aquinas de vector soporte (del ingl\'es support-vector machines, SVM) son un conjunto de algoritmos de aprendizaje supervisado desarrollados por Vladimir Vapnik y su equipo en los laboratorios de AT\&T Bell. Estos m\'etodos est\'an propiamente relacionados con problemas de clasificaci\'on y regresi\'on. Dado un conjunto de ejemplos de formaci\'on (de muestras) podemos etiquetar las clases y formar una SVM para construir un modelo que prediga la clase de una nueva muestra. Intuitivamente, una SVM es un modelo que representa a los puntos de muestra en el espacio, separando las clases a 2 espacios lo m\'as amplios posibles mediante un hiperplano de separaci\'on definido como el vector entre los 2 puntos, de las 2 clases, m\'as cercanos al que se llama vector soporte. Cuando las nuevas muestras se ponen en correspondencia con dicho modelo, en funci\'on de los espacios a los que pertenezcan, pueden ser clasificadas a una o la otra clase. M\'as formalmente, una SVM construye un hiperplano o conjunto de hiperplanos en un espacio de dimensionalidad muy alta (o incluso infinita) que puede ser utilizado en problemas de clasificaci\'on o regresi\'on. Una buena separaci\'on entre las clases permitir\'a una clasificaci\'on correcta.},
-  copyright = {Creative Commons Attribution-ShareAlike License},
-  langid = {spanish},
-  annotation = {Page Version ID: 166571975},
-  file = {/Users/gonzalo/Zotero/storage/FALVP96U/index.html}
 }
 
 @inproceedings{mardiaDistributionTheoryMisesFisher1975,
@@ -1084,34 +533,6 @@
   file = {/Users/gonzalo/Zotero/storage/JY9XJQQX/Mckenzie and Damelin - 2019 - Power Weighted Shortest Paths for Clustering Eucli.pdf}
 }
 
-@article{MinkowskiDistance2025,
-  title = {Minkowski Distance},
-  year = 2025,
-  month = jul,
-  journal = {Wikipedia},
-  urldate = {2025-09-06},
-  abstract = {The Minkowski distance or Minkowski metric is a metric in a normed vector space which can be considered as a generalization of both the Euclidean distance and the Manhattan distance. It is named after the Polish mathematician Hermann Minkowski.},
-  copyright = {Creative Commons Attribution-ShareAlike License},
-  langid = {english},
-  annotation = {Page Version ID: 1303076037},
-  file = {/Users/gonzalo/Zotero/storage/KDJ5M2LV/index.html}
-}
-
-@book{morganRiemannianGeometryBeginners1993,
-  title = {Riemannian Geometry : A Beginner's Guide},
-  shorttitle = {Riemannian Geometry},
-  author = {Morgan, Frank},
-  year = 1993,
-  publisher = {{Boston : Jones and Bartlett Publishers}},
-  urldate = {2025-08-25},
-  abstract = {119 p. : 24 cm; Includes bibliographical references (p. [105]-108) and indexes},
-  collaborator = {{Internet Archive}},
-  isbn = {978-0-86720-242-7},
-  langid = {english},
-  keywords = {Geometry Riemannian},
-  file = {/Users/gonzalo/Zotero/storage/4D52RI8M/Morgan - 1993 - Riemannian geometry  a beginner's guide.pdf}
-}
-
 @phdthesis{munozEstimacionNoParametrica2011,
   title = {{Estimaci\'on no param\'etrica de la densidad en variedades Riemannianas}},
   author = {Mu{\~n}oz, Andres Leandro},
@@ -1119,26 +540,6 @@
   langid = {spanish},
   school = {Universidad de Buenos Aires},
   file = {/Users/gonzalo/Zotero/storage/8NLUQYY3/Munoz - Estimacio´n no param´etrica de la densidad en vari.pdf}
-}
-
-@article{NormMathematics2025,
-  title = {Norm (Mathematics)},
-  year = 2025,
-  month = sep,
-  journal = {Wikipedia},
-  urldate = {2025-09-06},
-  abstract = {In mathematics, a norm is a function from a real or complex vector space to the non-negative real numbers that behaves in certain ways like the distance from the origin: it commutes with scaling, obeys a form of the triangle inequality, and zero is only at the origin. In particular, the Euclidean distance in a Euclidean space is defined by a norm on the associated Euclidean vector space, called the Euclidean norm, the 2-norm, or, sometimes, the magnitude or length of the vector. This norm can be defined as the square root of the inner product of a vector with itself. A seminorm satisfies the first two properties of a norm but may be zero for vectors other than the origin. A vector space with a specified norm is called a normed vector space. In a similar manner, a vector space with a seminorm is called a seminormed vector space. The term pseudonorm has been used for several related meanings. It may be a synonym of "seminorm". It can also refer to a norm that can take infinite values or to certain functions parametrised by a directed set.},
-  copyright = {Creative Commons Attribution-ShareAlike License},
-  langid = {english},
-  annotation = {Page Version ID: 1309569038},
-  file = {/Users/gonzalo/Zotero/storage/T827VL32/index.html}
-}
-
-@article{odonnellDEMOCRACIADELEGATIVA,
-  title = {{DEMOCRACIA DELEGATIVA}},
-  author = {O'Donnell, Guillermo},
-  langid = {spanish},
-  file = {/Users/gonzalo/Zotero/storage/NQWU56Y3/O’Donnell - DEMOCRACIA DELEGATIVA.pdf}
 }
 
 @article{parzenEstimationProbabilityDensity1962,
@@ -1181,27 +582,6 @@
   file = {/Users/gonzalo/Zotero/storage/DEZE5FJQ/Pelletier - 2005 - Kernel density estimation on Riemannian manifolds.pdf}
 }
 
-@article{RedNeuronalArtificial2025,
-  title = {{Red neuronal artificial}},
-  year = 2025,
-  month = dec,
-  journal = {Wikipedia, la enciclopedia libre},
-  urldate = {2026-01-26},
-  abstract = {En el aprendizaje autom\'atico, una red neuronal artificial (abreviada ANN o NN) es un modelo dentro de los llamados sistemas conexionistas, inspirado en la estructura y funci\'on de las redes neuronales biol\'ogicas en los cerebros animales. Una ANN consta de unidades o nodos conectados llamados neuronas artificiales, que modelan vagamente las neuronas del cerebro. Estas est\'an conectadas por aristas, que modelan las sinapsis del cerebro. Cada neurona artificial recibe <<se\~nales>> de las neuronas conectadas, luego las procesa y env\'ia una se\~nal a otras neuronas conectadas. La <<se\~nal>> es un n\'umero real, y la salida de cada neurona se calcula mediante una funci\'on no lineal de la suma de sus entradas, llamada funci\'on de activaci\'on. La fuerza de la se\~nal en cada conexi\'on est\'a determinada por un peso, que se ajusta durante el proceso de aprendizaje.   Por lo general, las neuronas se agrupan en capas. Las diferentes capas pueden realizar diferentes transformaciones en sus entradas. Las se\~nales viajan desde la primera capa (la capa de entrada) hasta la \'ultima capa (la capa de salida), posiblemente pasando por m\'ultiples capas intermedias (capas ocultas). Una red se denomina t\'ipicamente red neuronal profunda si tiene al menos dos capas ocultas.},
-  copyright = {Creative Commons Attribution-ShareAlike License},
-  langid = {spanish},
-  annotation = {Page Version ID: 171081936},
-  file = {/Users/gonzalo/Zotero/storage/RTJ3Q679/index.html}
-}
-
-@book{RiemannianGeometry,
-  title = {Riemannian {{Geometry}}},
-  urldate = {2025-08-26},
-  abstract = {Riemannian Geometry is an expanded edition of a highly acclaimed and successful textbook (originally published in Portuguese) for first-year graduate students in mathematics and physics. The author's treatment goes very directly to the basic language of Riemannian geometry and immediately presents some of its most fundamental theorems. It is elementary, assuming only a modest background from readers, making it suitable for a wide variety of students and course structures. Its selection of topics has been deemed "superb" by teachers who have used the text. A significant feature of the book is its powerful and revealing structure, beginning simply with the definition of a differentiable manifold and ending with one of the most important results in Riemannian geometry, a proof of the Sphere Theorem. The text abounds with basic definitions and theorems, examples, applications, and numerous exercises to test the student's understanding and extend knowledge and insight intothe subject. Instructors and students alike will find the work to be a significant contribution to this highly applicable and stimulating subject.},
-  langid = {english},
-  file = {/Users/gonzalo/Zotero/storage/E9ZDBGL4/9780817634902.html}
-}
-
 @inproceedings{rifaiManifoldTangentClassifier2011,
   title = {The {{Manifold Tangent Classifier}}},
   booktitle = {Advances in {{Neural Information Processing Systems}}},
@@ -1212,18 +592,6 @@
   urldate = {2023-03-02},
   abstract = {We combine three important ideas present in previous work for building classi- fiers: the semi-supervised hypothesis (the input distribution contains information about the classifier), the unsupervised manifold hypothesis (data density concen- trates near low-dimensional manifolds), and the manifold hypothesis for classifi- cation (different classes correspond to disjoint manifolds separated by low den- sity). We exploit a novel algorithm for capturing manifold structure (high-order contractive auto-encoders) and we show how it builds a topological atlas of charts, each chart being characterized by the principal singular vectors of the Jacobian of a representation mapping. This representation learning algorithm can be stacked to yield a deep architecture, and we combine it with a domain knowledge-free version of the TangentProp algorithm to encourage the classifier to be insensitive to local directions changes along the manifold. Record-breaking classification results are obtained.},
   file = {/Users/gonzalo/Zotero/storage/D2MEYF5H/Rifai et al. - 2011 - The Manifold Tangent Classifier.pdf}
-}
-
-@article{rodriguezRobustNonparametricRegression2009,
-  title = {Robust Nonparametric Regression on {{Riemannian}} Manifolds},
-  author = {Rodriguez, Daniela and Henry, Guillermo},
-  year = 2009,
-  month = jul,
-  journal = {Journal of Nonparametric Statistics},
-  volume = {21},
-  doi = {10.1080/10485250902846439},
-  abstract = {In this study, we introduce two families of robust kernel-based regression estimators when the regressors are random objects taking values in a Riemannian manifold. The first proposal is a local M-estimator based on kernel methods, adapted to the geometry of the manifold. For the second proposal, the weights are based on k-nearest neighbour kernel methods. Strong uniform consistent results as well as the asymptotical normality of both families are established. Finally, a Monte Carlo study is carried out to compare the performance of the robust proposed estimators with that of the classical ones, in normal and contaminated samples and a cross-validation method is discussed.},
-  file = {/Users/gonzalo/Zotero/storage/FW4XWDTR/Rodriguez and Henry - 2009 - Robust nonparametric regression on Riemannian mani.pdf}
 }
 
 @article{rosenblattRemarksNonparametricEstimates1956,
@@ -1243,22 +611,6 @@
   file = {/Users/gonzalo/Zotero/storage/NGJQQ8SZ/Rosenblatt - 1956 - Remarks on Some Nonparametric Estimates of a Density Function.pdf}
 }
 
-@inproceedings{sajamaEstimatingComputingDensity2005,
-  title = {Estimating and Computing Density Based Distance Metrics},
-  booktitle = {Proceedings of the 22nd International Conference on {{Machine}} Learning  - {{ICML}} '05},
-  author = {{Sajama} and Orlitsky, Alon},
-  year = 2005,
-  pages = {760--767},
-  publisher = {ACM Press},
-  address = {Bonn, Germany},
-  doi = {10.1145/1102351.1102447},
-  urldate = {2025-09-07},
-  copyright = {https://www.acm.org/publications/policies/copyright\_policy\#Background},
-  isbn = {978-1-59593-180-1},
-  langid = {english},
-  file = {/Users/gonzalo/Zotero/storage/NSLR6N2L/Sajama and Orlitsky - 2005 - Estimating and computing density based distance metrics.pdf}
-}
-
 @inproceedings{sapienzaWeightedGeodesicDistance2018,
   title = {Weighted {{Geodesic Distance Following Fermat}}'s {{Principle}}},
   author = {Sapienza, Facundo and Jonckheere, Matthieu and Groisman, Pablo},
@@ -1266,23 +618,6 @@
   abstract = {We propose a density-based estimator for weighted geodesic distances suitable for data lying on a manifold of lower dimension than ambient space and sampled from a possibly nonuniform distribution. After discussing its properties and implementation, we evaluate its performance as a tool for clustering tasks. A discussion on the consistency of the estimator is also given.},
   langid = {english},
   file = {/Users/gonzalo/Zotero/storage/983EUZCU/Sapienza et al. - 2018 - WEIGHTED GEODESIC DISTANCE FOLLOWING FERMAT’S PRIN.pdf}
-}
-
-@article{silvermanUsingKernelDensity1981,
-  title = {Using {{Kernel Density Estimates}} to {{Investigate Multimodality}}},
-  author = {Silverman, B. W.},
-  year = 1981,
-  month = sep,
-  journal = {Journal of the Royal Statistical Society: Series B (Methodological)},
-  volume = {43},
-  number = {1},
-  pages = {97--99},
-  issn = {00359246},
-  doi = {10.1111/j.2517-6161.1981.tb01155.x},
-  urldate = {2023-03-02},
-  abstract = {A technique for using kernel density estimates to investigate the number of modes in a population is described and discussed. The amount of smoothing is chosen automatically in a natural way.},
-  langid = {english},
-  file = {/Users/gonzalo/Zotero/storage/GY2IAI9M/Silverman - 1981 - Using Kernel Density Estimates to Investigate Mult.pdf}
 }
 
 @inproceedings{simardTangentPropFormalism1991,
@@ -1295,45 +630,6 @@
   urldate = {2023-03-02},
   abstract = {In many machine learning applications, one has access, not only to training  data, but also to some high-level a priori knowledge about the desired be(cid:173) havior of the system. For example, it is known in advance that the output  of a character recognizer should be invariant with respect to small spa(cid:173) tial distortions of the input images (translations, rotations, scale changes,  etcetera).  We have implemented a scheme that allows a network to learn the deriva(cid:173) tive of its outputs with respect to distortion operators of our choosing.  This not only reduces the learning time and the amount of training data,  but also provides a powerful language for specifying what generalizations  we wish the network to perform.},
   file = {/Users/gonzalo/Zotero/storage/ZFIBR7BL/Simard et al. - 1991 - Tangent Prop - A formalism for specifying selected.pdf}
-}
-
-@article{SingularValueDecomposition2025,
-  title = {Singular Value Decomposition},
-  year = 2025,
-  month = aug,
-  journal = {Wikipedia},
-  urldate = {2025-09-01},
-  abstract = {In linear algebra, the singular value decomposition (SVD) is a factorization of a real or complex matrix into a rotation, followed by a rescaling followed by another rotation. It generalizes the eigendecomposition of a square normal matrix with an orthonormal eigenbasis to any \nolinebreak{}                        m         \texttimes{}         n                 \textbraceleft\textbackslash displaystyle m\textbackslash times n\textbraceright{}    \nolinebreak{} matrix. It is related to the polar decomposition. Specifically, the singular value decomposition of an                         m         \texttimes{}         n                 \textbraceleft\textbackslash displaystyle m\textbackslash times n\textbraceright{}     complex matrix \nolinebreak{}                                   M                          \textbraceleft\textbackslash displaystyle \textbackslash mathbf \textbraceleft M\textbraceright{} \textbraceright{}    \nolinebreak{} is a factorization of the form                                    M                  =                    U           {$\Sigma$}                        V                            {$\ast$}                                          ,                 \textbraceleft\textbackslash displaystyle \textbackslash mathbf \textbraceleft M\textbraceright{} =\textbackslash mathbf \textbraceleft U\textbackslash Sigma V\textasciicircum\textbraceleft *\textbraceright\textbraceright{} ,\textbraceright{}     where \nolinebreak{}                                   U                          \textbraceleft\textbackslash displaystyle \textbackslash mathbf \textbraceleft U\textbraceright{} \textbraceright{}    \nolinebreak{} is an \nolinebreak{}                        m         \texttimes{}         m                 \textbraceleft\textbackslash displaystyle m\textbackslash times m\textbraceright{}    \nolinebreak{} complex unitary matrix,                                    {$\Sigma$}                          \textbraceleft\textbackslash displaystyle \textbackslash mathbf \textbraceleft\textbackslash Sigma \textbraceright{} \textbraceright{}     is an                         m         \texttimes{}         n                 \textbraceleft\textbackslash displaystyle m\textbackslash times n\textbraceright{}     rectangular diagonal matrix with non-negative real numbers on the diagonal, \nolinebreak{}                                   V                          \textbraceleft\textbackslash displaystyle \textbackslash mathbf \textbraceleft V\textbraceright{} \textbraceright{}    \nolinebreak{} is an                         n         \texttimes{}         n                 \textbraceleft\textbackslash displaystyle n\textbackslash times n\textbraceright{}     complex unitary matrix, and                                                 V                                   {$\ast$}                                     \textbraceleft\textbackslash displaystyle \textbackslash mathbf \textbraceleft V\textbraceright{} \textasciicircum\textbraceleft *\textbraceright\textbraceright{}     is the conjugate transpose of \nolinebreak{}                                   V                          \textbraceleft\textbackslash displaystyle \textbackslash mathbf \textbraceleft V\textbraceright{} \textbraceright{}    \nolinebreak. Such decomposition always exists for any complex matrix.  If \nolinebreak{}                                   M                          \textbraceleft\textbackslash displaystyle \textbackslash mathbf \textbraceleft M\textbraceright{} \textbraceright{}    \nolinebreak{} is real, then \nolinebreak{}                                   U                          \textbraceleft\textbackslash displaystyle \textbackslash mathbf \textbraceleft U\textbraceright{} \textbraceright{}    \nolinebreak{} and \nolinebreak{}                                   V                          \textbraceleft\textbackslash displaystyle \textbackslash mathbf \textbraceleft V\textbraceright{} \textbraceright{}    \nolinebreak{} can be guaranteed to be real orthogonal matrices; in such contexts, the SVD is often denoted                                    U                             {$\Sigma$}                                          V                                                  T                                          .                 \textbraceleft\textbackslash displaystyle \textbackslash mathbf \textbraceleft U\textbraceright{} \textbackslash mathbf \textbraceleft\textbackslash Sigma \textbraceright{} \textbackslash mathbf \textbraceleft V\textbraceright{} \textasciicircum\textbraceleft\textbackslash mathrm \textbraceleft T\textbraceright{} \textbraceright.\textbraceright{}    The diagonal entries                                    {$\sigma$}                        i                             =                    {$\Sigma$}                        i             i                                     \textbraceleft\textbackslash displaystyle \textbackslash sigma \_\textbraceleft i\textbraceright =\textbackslash Sigma \_\textbraceleft ii\textbraceright\textbraceright{}     of                                    {$\Sigma$}                          \textbraceleft\textbackslash displaystyle \textbackslash mathbf \textbraceleft\textbackslash Sigma \textbraceright{} \textbraceright{}     are uniquely determined by \nolinebreak{}                                   M                          \textbraceleft\textbackslash displaystyle \textbackslash mathbf \textbraceleft M\textbraceright{} \textbraceright{}    \nolinebreak{} and are known as the singular values of \nolinebreak{}                                   M                          \textbraceleft\textbackslash displaystyle \textbackslash mathbf \textbraceleft M\textbraceright{} \textbraceright{}    \nolinebreak. The number of non-zero singular values is equal to the rank of \nolinebreak{}                                   M                          \textbraceleft\textbackslash displaystyle \textbackslash mathbf \textbraceleft M\textbraceright{} \textbraceright{}    \nolinebreak. The columns of \nolinebreak{}                                   U                          \textbraceleft\textbackslash displaystyle \textbackslash mathbf \textbraceleft U\textbraceright{} \textbraceright{}    \nolinebreak{} and the columns of \nolinebreak{}                                   V                          \textbraceleft\textbackslash displaystyle \textbackslash mathbf \textbraceleft V\textbraceright{} \textbraceright{}    \nolinebreak{} are called left-singular vectors and right-singular vectors of \nolinebreak{}                                   M                          \textbraceleft\textbackslash displaystyle \textbackslash mathbf \textbraceleft M\textbraceright{} \textbraceright{}    \nolinebreak, respectively. They form two sets of orthonormal bases \nolinebreak{}                                                u                                   1                             ,         \dots{}         ,                                 u                                   m                                     \textbraceleft\textbackslash displaystyle \textbackslash mathbf \textbraceleft u\textbraceright{} \_\textbraceleft 1\textbraceright,\textbackslash ldots ,\textbackslash mathbf \textbraceleft u\textbraceright{} \_\textbraceleft m\textbraceright\textbraceright{}    \nolinebreak{} and \nolinebreak{}                                                v                                   1                             ,         \dots{}         ,                                 v                                   n                             ,                 \textbraceleft\textbackslash displaystyle \textbackslash mathbf \textbraceleft v\textbraceright{} \_\textbraceleft 1\textbraceright,\textbackslash ldots ,\textbackslash mathbf \textbraceleft v\textbraceright{} \_\textbraceleft n\textbraceright,\textbraceright{}    \nolinebreak{} and if they are sorted so that the singular values                                    {$\sigma$}                        i                                     \textbraceleft\textbackslash displaystyle \textbackslash sigma \_\textbraceleft i\textbraceright\textbraceright{}     with value zero are all in the highest-numbered columns (or rows), the singular value decomposition can be written as                                   M                  =                    {$\sum$}                        i             =             1                                   r                                        {$\sigma$}                        i                                                     u                                   i                                                     v                                   i                                   {$\ast$}                             ,                 \textbraceleft\textbackslash displaystyle \textbackslash mathbf \textbraceleft M\textbraceright{} =\textbackslash sum \_\textbraceleft i=1\textbraceright\textasciicircum\textbraceleft r\textbraceright\textbackslash sigma \_\textbraceleft i\textbraceright\textbackslash mathbf \textbraceleft u\textbraceright{} \_\textbraceleft i\textbraceright\textbackslash mathbf \textbraceleft v\textbraceright{} \_\textbraceleft i\textbraceright\textasciicircum\textbraceleft *\textbraceright,\textbraceright{}    where                         r         {$\leq$}         min         \textbraceleft{}         m         ,         n         \textbraceright{}                 \textbraceleft\textbackslash displaystyle r\textbackslash leq \textbackslash min\textbackslash\textbraceleft m,n\textbackslash\textbraceright\textbraceright{}     is the rank of \nolinebreak{}                                   M                  .                 \textbraceleft\textbackslash displaystyle \textbackslash mathbf \textbraceleft M\textbraceright{} .\textbraceright{}    \nolinebreak{} The SVD is not unique. However, it is always possible to choose the decomposition such that the singular values                                    {$\Sigma$}                        i             i                                     \textbraceleft\textbackslash displaystyle \textbackslash Sigma \_\textbraceleft ii\textbraceright\textbraceright{}     are in descending order. In this case,                                    {$\Sigma$}                          \textbraceleft\textbackslash displaystyle \textbackslash mathbf \textbraceleft\textbackslash Sigma \textbraceright{} \textbraceright{}     (but not \nolinebreak{}                                   U                          \textbraceleft\textbackslash displaystyle \textbackslash mathbf \textbraceleft U\textbraceright{} \textbraceright{}    \nolinebreak{} and \nolinebreak{}                                   V                          \textbraceleft\textbackslash displaystyle \textbackslash mathbf \textbraceleft V\textbraceright{} \textbraceright{}    \nolinebreak ) is uniquely determined by \nolinebreak{}                                   M                  .                 \textbraceleft\textbackslash displaystyle \textbackslash mathbf \textbraceleft M\textbraceright{} .\textbraceright{}    \nolinebreak{} The term sometimes refers to the compact SVD, a similar decomposition \nolinebreak{}                                   M                  =                                 U             {$\Sigma$}             V                                   {$\ast$}                                     \textbraceleft\textbackslash displaystyle \textbackslash mathbf \textbraceleft M\textbraceright{} =\textbackslash mathbf \textbraceleft U\textbackslash Sigma V\textbraceright{} \textasciicircum\textbraceleft *\textbraceright\textbraceright{}    \nolinebreak{} in which \nolinebreak{}                                   {$\Sigma$}                          \textbraceleft\textbackslash displaystyle \textbackslash mathbf \textbraceleft\textbackslash Sigma \textbraceright{} \textbraceright{}    \nolinebreak{} is square diagonal of size \nolinebreak{}                        r         \texttimes{}         r         ,                 \textbraceleft\textbackslash displaystyle r\textbackslash times r,\textbraceright{}    \nolinebreak{} where \nolinebreak{}                        r         {$\leq$}         min         \textbraceleft{}         m         ,         n         \textbraceright{}                 \textbraceleft\textbackslash displaystyle r\textbackslash leq \textbackslash min\textbackslash\textbraceleft m,n\textbackslash\textbraceright\textbraceright{}    \nolinebreak{} is the rank of \nolinebreak{}                                   M                  ,                 \textbraceleft\textbackslash displaystyle \textbackslash mathbf \textbraceleft M\textbraceright{} ,\textbraceright{}    \nolinebreak{} and has only the non-zero singular values. In this variant, \nolinebreak{}                                   U                          \textbraceleft\textbackslash displaystyle \textbackslash mathbf \textbraceleft U\textbraceright{} \textbraceright{}    \nolinebreak{} is an \nolinebreak{}                        m         \texttimes{}         r                 \textbraceleft\textbackslash displaystyle m\textbackslash times r\textbraceright{}    \nolinebreak{} semi-unitary matrix and                                    V                          \textbraceleft\textbackslash displaystyle \textbackslash mathbf \textbraceleft V\textbraceright{} \textbraceright{}     is an \nolinebreak{}                        n         \texttimes{}         r                 \textbraceleft\textbackslash displaystyle n\textbackslash times r\textbraceright{}    \nolinebreak{} semi-unitary matrix, such that                                                 U                                   {$\ast$}                                        U                  =                                 V                                   {$\ast$}                                        V                  =                                 I                                   r                             .                 \textbraceleft\textbackslash displaystyle \textbackslash mathbf \textbraceleft U\textbraceright{} \textasciicircum\textbraceleft *\textbraceright\textbackslash mathbf \textbraceleft U\textbraceright{} =\textbackslash mathbf \textbraceleft V\textbraceright{} \textasciicircum\textbraceleft *\textbraceright\textbackslash mathbf \textbraceleft V\textbraceright{} =\textbackslash mathbf \textbraceleft I\textbraceright{} \_\textbraceleft r\textbraceright.\textbraceright{}    Mathematical applications of the SVD include computing the pseudoinverse, matrix approximation, and determining the rank, range, and null space of a matrix.  The SVD is also extremely useful in many areas of science, engineering, and statistics, such as signal processing, least squares fitting of data, and process control.},
-  copyright = {Creative Commons Attribution-ShareAlike License},
-  langid = {english},
-  annotation = {Page Version ID: 1308077257},
-  file = {/Users/gonzalo/Zotero/storage/ISH6KZIA/Singular_value_decomposition.html}
-}
-
-@misc{tangTutorialTangentPropagation2009,
-  title = {Tutorial on {{Tangent Propagation}}},
-  author = {Tang, Yichuan},
-  year = 2009,
-  month = feb,
-  langid = {english},
-  file = {/Users/gonzalo/Zotero/storage/DMFPWIXT/Tang - Tutorial on Tangent Propagation.pdf}
-}
-
-@article{taylorClassificationKernelDensity1997,
-  title = {Classification and Kernel Density Estimation},
-  author = {Taylor, Charles},
-  year = 1997,
-  month = jan,
-  journal = {Vistas in Astronomy},
-  volume = {41},
-  number = {3},
-  pages = {411--417},
-  issn = {00836656},
-  doi = {10.1016/S0083-6656(97)00046-9},
-  urldate = {2023-03-02},
-  abstract = {The method of kernel density estimation can be readily used for the purposes of classification, and an easy-to-use package (ALLOCBO) is now in wide circulation. It is known that this method performs well (at least in relative terms) in the case of bimodal, or heavily skewed distributions.},
-  langid = {english},
-  file = {/Users/gonzalo/Zotero/storage/AKKJZT3R/Taylor - 1997 - Classification and kernel density estimation.pdf}
 }
 
 @article{tenenbaumGlobalGeometricFramework2000,
@@ -1363,20 +659,6 @@
   urldate = {2023-03-02},
   abstract = {Nonlinear dimensionality reduction is formulated here as the problem of trying to  find a Euclidean feature-space embedding of a set of observations that preserves  as closely as possible their intrinsic metric structure - the distances between points  on  the  observation manifold as  measured along geodesic paths.  Our isometric  feature mapping procedure, or isomap, is able to reliably recover low-dimensional  nonlinear structure in  realistic  perceptual data  sets,  such as  a manifold  of face  images,  where  conventional global  mapping  methods  find  only  local  minima.  The  recovered  map  provides  a canonical  set  of globally  meaningful  features,  which allows perceptual transformations such as interpolation, extrapolation, and  analogy - highly nonlinear transformations in the original observation space - to  be computed with simple linear operations in feature space.},
   file = {/Users/gonzalo/Zotero/storage/ZMNFLLEB/Tenenbaum - 1997 - Mapping a Manifold of Perceptual Observations.pdf}
-}
-
-@book{tuIntroductionManifolds2011,
-  title = {An {{Introduction}} to {{Manifolds}}},
-  author = {Tu, Loring W.},
-  year = 2011,
-  series = {Universitext},
-  publisher = {Springer New York},
-  address = {New York, NY},
-  doi = {10.1007/978-1-4419-7400-6},
-  urldate = {2023-03-02},
-  isbn = {978-1-4419-7399-3 978-1-4419-7400-6},
-  langid = {english},
-  file = {/Users/gonzalo/Zotero/storage/TRQJZ6B6/Tu - 2011 - An Introduction to Manifolds.pdf}
 }
 
 @inproceedings{vincentDensitySensitiveMetrics2003,
@@ -1437,38 +719,6 @@
   file = {/Users/gonzalo/Zotero/storage/662G7HUL/Wand and Jones - 1995 - Kernel Smoothing.pdf}
 }
 
-@article{wandMultivariatePluginBandwidth1994,
-  title = {Multivariate Plug-in Bandwidth Selection},
-  author = {Wand, Matt P. and Jones, M. Chris},
-  year = 1994,
-  journal = {Computational Statistics},
-  volume = {9},
-  number = {2},
-  pages = {97--116},
-  publisher = {Heidelberg: Physica-Verlag,[1992-},
-  file = {/Users/gonzalo/Zotero/storage/EHBPWPM5/Wand and Jones - 1994 - Multivariate plug-in bandwidth selection.pdf}
-}
-
-@article{wangNonparametricDensityEstimation2019,
-  title = {Nonparametric {{Density Estimation}} for {{High-Dimensional Data}} - {{Algorithms}} and {{Applications}}},
-  author = {Wang, Zhipeng and Scott, David W.},
-  year = 2019,
-  month = jul,
-  journal = {WIREs Comp Stat},
-  volume = {11},
-  number = {4},
-  eprint = {1904.00176},
-  primaryclass = {cs, stat},
-  issn = {1939-5108, 1939-0068},
-  doi = {10.1002/wics.1461},
-  urldate = {2023-03-02},
-  abstract = {Density Estimation is one of the central areas of statistics whose purpose is to estimate the probability density function underlying the observed data. It serves as a building block for many tasks in statistical inference, visualization, and machine learning. Density Estimation is widely adopted in the domain of unsupervised learning especially for the application of clustering. As big data become pervasive in almost every area of data sciences, analyzing high-dimensional data that have many features and variables appears to be a major focus in both academia and industry. Highdimensional data pose challenges not only from the theoretical aspects of statistical inference, but also from the algorithmic/computational considerations of machine learning and data analytics. This paper reviews a collection of selected nonparametric density estimation algorithms for high-dimensional data, some of them are recently published and provide interesting mathematical insights. The important application domain of nonparametric density estimation, such as modal clustering, are also included in this paper. Several research directions related to density estimation and high-dimensional data analysis are suggested by the authors.},
-  archiveprefix = {arXiv},
-  langid = {english},
-  keywords = {Computer Science - Machine Learning,Statistics - Computation,Statistics - Machine Learning},
-  file = {/Users/gonzalo/Zotero/storage/5C9PF8NB/Wang and Scott - 2019 - Nonparametric Density Estimation for High-Dimensio.pdf}
-}
-
 @article{wikipediaEntornoMatematica2025,
   title = {{Entorno (matem\'atica)}},
   author = {Wikipedia},
@@ -1511,19 +761,3 @@
   file = {/Users/gonzalo/Zotero/storage/L2RKJPE6/index.html}
 }
 
-@article{yuDensitybasedGeodesicDistance2016,
-  title = {Density-Based Geodesic Distance for Identifying the Noisy and Nonlinear Clusters},
-  author = {Yu, Jaehong and Kim, Seoung Bum},
-  year = 2016,
-  month = sep,
-  journal = {Information Sciences},
-  volume = {360},
-  pages = {231--243},
-  issn = {0020-0255},
-  doi = {10.1016/j.ins.2016.04.032},
-  urldate = {2023-03-02},
-  abstract = {Clustering analysis can facilitate the extraction of implicit patterns in a dataset and elicit its natural groupings without requiring prior classification information. For superior clustering analysis results, a number of distance measures have been proposed. Recently, geodesic distance has been widely applied to clustering algorithms for nonlinear groupings. However, geodesic distance is sensitive to noise and hence, geodesic distance-based clustering may fail to discover nonlinear clusters in the region of the noise. In this study, we propose a density-based geodesic distance that can identify clusters in nonlinear and noisy situations. Experiments on various simulation and benchmark datasets are conducted to examine the properties of the proposed geodesic distance and to compare its performance with that of existing distance measures. The experimental results confirm that a clustering algorithm with the proposed distance measure demonstrated superior performance compared to the competitors; this was especially true when the cluster structures in the data were inherently noisy and nonlinearly patterned.},
-  langid = {english},
-  keywords = {Geodesic distance,Mutual neighborhood-based density coefficient,Noisy data clustering,Nonlinearity},
-  file = {/Users/gonzalo/Zotero/storage/LL74HFAV/Yu and Kim - 2016 - Density-based geodesic distance for identifying th.pdf;/Users/gonzalo/Zotero/storage/PK6FXSRE/S002002551630281X.html}
-}


### PR DESCRIPTION
## Resumen

Recorta `docs/references.bib` de **110 a 53 entradas** eliminando todo lo que no está citado en ninguno de los `.typ` del repo (`tesis.typ`, `plan.typ`, `poster.typ`, `poster-template.typ`, `seminario-modesto.typ`).

766 líneas eliminadas, ningún cambio funcional. Pre-commit hook verifica que la tesis y demás documentos siguen compilando.

## Método

```bash
# 1. extraer todas las claves @key de los .typ
grep -oE "@[A-Za-z][A-Za-z0-9_:.-]*" docs/*.typ | sed 's/^@//' | sort -u
# 2. extraer todas las claves del .bib
grep -oE "^@[A-Za-z]+\{[^,]+," docs/references.bib | sed -E 's/^@[A-Za-z]+\{([^,]+),/\1/'
# 3. remover del .bib lo que está en (2) pero no en (1)
```

## Entradas removidas (57)

<details>
<summary>Lista completa</summary>

- `116ProbabilityCalibration`
- `AdelaideResearchScholarship2014`
- `AffineConnection2024`
- `Autoencoder2025`
- `ConvergenceRandomVariables2025`
- `Crossentropy2025`
- `DeepLearning2025`
- `DistanciaMahalanobis2024`
- `DocumentZbl075253001`
- `EntornoMatematica2024`
- `FunctionMathematics2025`
- `GradientBoosting2025`
- `KillersSomebodyTold`
- `LinearDiscriminantAnalysis2022`
- `MaquinaVectoresSoporte2025`
- `MinkowskiDistance2025`
- `NormMathematics2025`
- `RedNeuronalArtificial2025`
- `RiemannianGeometry`
- `SingularValueDecomposition2025`
- `bengioCurseHighlyVariable2005`
- `bengioLearningEigenfunctionsLinks2004`
- `beyerWhenNearestNeighbor1999`
- `bickelLocalPolynomialRegression2007`
- `calderHamiltonJacobiEquationsGraphs2022`
- `carpioFingerprintsCancerPersistent2019`
- `chaconDatadrivenDensityDerivative2013`
- `chavelRiemannianGeometryModern2006`
- `chenComprehensiveApproachMode2015`
- `claudecoulombeWhoFirstAdvanced2021`
- `davenportBayesRuleRandom2014`
- `duongCrossvalidationBandwidthMatrices2005`
- `federerCurvatureMeasures1959`
- `fisherDesignExperiments1935`
- `fukunagaIntroductionStatisticalPattern2013`
- `gallotRiemannianGeometry2004`
- `garcia-portuguesShortCourseNonparametric2022`
- `huberProjectionPursuit1985`
- `jenq-nenghwangNonparametricMultivariateDensity1994`
- `kohonenSelfOrganizationAssociativeMemory1988`
- `kohonenSelforganizedFormationTopologically1982`
- `kokluMulticlassClassificationDry2020`
- `korolyukAsymptoticTheoryUstatistics1988`
- `levinaMaximumLikelihoodEstimation`
- `levinaMaximumLikelihoodEstimation2004`
- `linShellTheoryStatistical2021`
- `morganRiemannianGeometryBeginners1993`
- `odonnellDEMOCRACIADELEGATIVA`
- `rodriguezRobustNonparametricRegression2009`
- `sajamaEstimatingComputingDensity2005`
- `silvermanUsingKernelDensity1981`
- `tangTutorialTangentPropagation2009`
- `taylorClassificationKernelDensity1997`
- `tuIntroductionManifolds2011`
- `wandMultivariatePluginBandwidth1994`
- `wangNonparametricDensityEstimation2019`
- `yuDensitybasedGeodesicDistance2016`

</details>

La mayoría son entradas tipo Wikipedia (los `*2024`/`*2025`) y borradores anteriores que dejaron papers en la `.bib` pero nunca terminaron siendo citados.

## Nota sobre la entrada de Daniela Rodriguez

`rodriguezRobustNonparametricRegression2009` (segundo paper de Rodríguez con Henry) **NO** está citado en la tesis, así que se elimina. El paper de Daniela que SÍ está citado es `henryKernelDensityEstimation2009`, que se conserva. Si querés sumar esa segunda referencia para fortalecer la conexión con la jurada, mejor agregarla intencionalmente al texto en un cambio posterior.

## Dependencia con otros PRs abiertos

- **#19 (correcciones Pablo)**: independiente. No tocan las mismas entradas.
- **#20 (revisión preprints)**: parcialmente solapado. PR #20 renombra 4 claves (Bengio Rep. Learning, Bijral, Little, Forzani). Las primeras 3 entradas se mantienen citadas y se renombran en ambos PRs; sin conflicto físico porque tocan campos distintos de la misma entrada. La cuarta (Forzani) la **excluí deliberadamente** de esta poda para no chocar con #20 ---queda como entrada no citada que se podría limpiar después.

🤖 Asistido por IA (Claude)