### PR TITLE
Balance de espacio en blanco

### DIFF
--- a/docs/tesis.typ
+++ b/docs/tesis.typ
@@ -1913,9 +1913,9 @@ $ sigma_"lunas" = 0.5 quad sigma_"circulos" = 0.2 quad sigma_"espirales" = 0.2 q
 
 #wide_figure(
   grid(columns: 3, gutter: 4pt,
-    image("img/lunas_hi-scatter.svg"),
-    image("img/circulos_hi-scatter.svg"),
-    image("img/espirales_hi-scatter.svg"),
+    image("img/lunas_hi-scatter.svg", height: 9em),
+    image("img/circulos_hi-scatter.svg", height: 9em),
+    image("img/espirales_hi-scatter.svg", height: 9em),
   ),
   caption: flex-caption["Lunas", "Círculos" y "Espirales" con "alto ruido"][ "Lunas", "Círculos" y "Espirales", alto ruido ],
 ) <fig-22>

--- a/docs/tesis.typ
+++ b/docs/tesis.typ
@@ -1696,7 +1696,7 @@ Entre el resto de los algoritmos, los no paramétricos son competitivos: #kn, #f
   )
 }
 
-#let highlights_figure(dataset, height: 8em, width: 140%) = {
+#let highlights_figure(dataset, height: 6em, width: 140%) = {
   let highlights = json("data/" + dataset + "-r2-highlights.json")
   let tabla_resumen = highlights_table(highlights)
 
@@ -1748,8 +1748,6 @@ Nótese que la frontera _lineal_ entre clases (al centro de la banda gris) apren
 === `circulos_lo` y `espirales_lo`
 
 #highlights_figure("circulos_lo")
-
-
 #highlights_figure("espirales_lo")
 
 Una inspección ocular a las fronteras de decisión revela las limitaciones de distintos algoritmos, siendo el caso de las espirales el más vistoso y pedagógico. #logr y #slr solo pueden dibujar fronteras "lineales", y como ninguna frontera lineal que corte la muestra logra dividirla en dos regiones con densidades de clase realmente diferentes, el algoritmo falla. #gnb falla de manera análoga, aunque su problema es otro - no lidia bien con distribuciones con densidades marginales muy similares.
@@ -1931,13 +1929,13 @@ En general, #fkdc y #fkn siguen siendo competitivos, pero el "terreno de juego" 
 
 ==== `lunas_hi`
 
-#highlights_figure("lunas_hi")
+#highlights_figure("lunas_hi", height: 5em)
 
 ==== `circulos_hi`
-#highlights_figure("circulos_hi")
+#highlights_figure("circulos_hi", height: 5em)
 
 ==== `espirales_hi`
-#highlights_figure("espirales_hi")
+#highlights_figure("espirales_hi", height: 5em)
 
 
 
@@ -2020,7 +2018,7 @@ Este dataset consiste en dos hélices del mismo diámetro y "enroscadas" en la m
 La clasificación dura con estimación de densidad por núcleos --- con distancia de Fermat o sin ella --- resulta ser superior a todas las alternativas en términos de exactitud --- ligeramente --- y $R^2$ --- por mucho. Encima de ello, #fkdc es todavía significativamente mejor en $R^2$ que #kdc por casi 5 puntos porcentualessalvo y consistentemente entoda las semillas salvo una particularmente negativa:
 
 #figure(
-  image("img/helices_0-r2-fkdc-vs-kdc.svg", height: 16em),
+  image("img/helices_0-r2-fkdc-vs-kdc.svg", height: 11em),
   caption: flex-caption(
     [$R^2$ apareado por semilla en `helices_0`: cada punto compara una corrida de #fkdc con la de #kdc para la misma semilla. #fkdc supera a #kdc en casi todas las semillas, con una ventaja mediana cercana a cinco puntos porcentuales.],
     [$R^2$ de #fkdc vs. #kdc por semilla en `helices_0`.],
@@ -2157,11 +2155,11 @@ Nuevamente #gbt es el mejor clasificador ($R^2 approx 0.92$), seguido por #gnb (
 
 === `helices_12`
 
-#highlights_figure("helices_12")
+#highlights_figure("helices_12", height: 5em)
 
 === `hueveras_12`
 
-#highlights_figure("hueveras_12")
+#highlights_figure("hueveras_12", height: 5em)
 
 Estos dos son de los datasets más difíciles del conjunto: la exactitud máxima de _cualquier_ clasificador apenas supera el 50%, valores muy cercanos al azar. Los clasificadores de densidad (#fkdc, #kdc) obtienen $R^2$ negativo, lo que indica un desempeño peor que el de un clasificador trivial. Estas geometrías, ya de por sí adversas aun sin ruido añadido, se vuelven intratables con este nivel de ruido en alta dimensión.
 
@@ -2230,6 +2228,7 @@ Dataset sintético bidimensional con tres clases en forma de anteojos ($k = 3$, 
   wide_figure(width: 160%,
     grid(columns: 3, gutter: 4pt, ..clfs.map(clf => image(
       "img/anteojos-" + clf + "-decision_boundary.svg",
+      height: 8em,
     ))),
     caption: flex-caption(
       [Fronteras de decisión de los nueve algoritmos evaluados sobre `anteojos` con semilla $s=#plotting_seed$. Se observa que #logr y #slr no logran separar las tres clases, mientras que los demás algoritmos alcanzan fronteras muy similares entre sí.],


### PR DESCRIPTION
## Summary

Reduce páginas medio vacías ajustando alturas de figuras conflictivas. **Branch basada en `resuelve-todos` (#23)**; cuando ese mergea, GitHub la rebasa automáticamente a `main`.

| Métrica | Antes | Después |
|---|---|---|
| Páginas totales | 114 | 112 |
| Páginas con <20 líneas de texto | 6 (la peor con 9) | 4 (la peor con 15) |
| Páginas con figuras-aisladas y ½ blanco abajo | varias | ≈1 (Figura 21 + prosa) |

### Cambios

1. `highlights_figure` default a **6em** (de 8em). Mantiene legibilidad y libera espacio para texto circundante.
2. **`_hi`** (lunas/circulos/espirales) y **`_12`** (helices/hueveras): height **5em**. Datasets consecutivos sin prosa entre figuras, donde la legibilidad del scatter es secundaria.
3. **R² apareado en helices_0** (`helices_0-r2-fkdc-vs-kdc.svg`): de 16em a **11em**. Ahora cabe con el pairplot + prosa en la misma página.
4. **Fronteras de decisión en anteojos** (Figura 31): cada imagen del grid 3×3 a height **8em**. Permite que la Figura 32 (digitos vs mnist) caiga en la misma página.
5. **Figura 21** (3 scatters de \_hi): height **9em**. Reduce el ⅓ blanco bajo la prosa descriptiva.

### Páginas mejoradas notablemente

- **Antes p82, p86, p87** (helices_0: pairplot, R² apareado, mean_test_score): cada una con ½ blanco. **Ahora p81, p85** consolidadas con prosa entre ellas.
- **Antes p100 y p103** (anteojos: scatter+highlights y fronteras): ½ vacías cada una. **Ahora p97, p98** llenas.
- **Antes p77-79** (lunas_hi, circulos_hi, espirales_hi): 1 highlight por página. **Ahora p76-77** caben 2 highlights en una página.

### Páginas que NO se pudieron rebalancear (limitación de layout)

- **p70** (Figura 17 fronteras alto ruido): figura 3×3 ocupa toda la página, aceptable.
- **p78** (Figura 21 + prosa): el highlights `lunas_hi` no entra después de la prosa con 5 viñetas; queda ⅓ blanco. Estructural.
- **p112** (final bibliografía): normal en cualquier libro.

## Test plan

- [ ] Compilar `make docs` y revisar visualmente.
- [ ] Foco en: §4.2.4 (\_hi), §4.3 (helices, hueveras), §4.4 (\_12, anteojos, digitos).
- [ ] Que ninguna figura crítica quede demasiado pequeña (los scatters de \_hi son los más reducidos, a 5em).

🤖 Asistido por IA (Claude)