### PR TITLE
Pulido visual: p107 densificada + Figura 32 más ancha

### DIFF
--- a/docs/tesis.typ
+++ b/docs/tesis.typ
@@ -2247,7 +2247,7 @@ Dataset sintético bidimensional con tres clases en forma de anteojos ($k = 3$, 
 
 === Datasets de alta dimensionalidad
 
-#figure(
+#wide_figure(width: 130%,
   image("img/anexo-hd-fkdc-vs-kdc.svg"),
   caption: flex-caption(
     [$R^2$ por semilla de #fkdc vs. #kdc en `digitos` ($D = 64$) y `mnist` ($D = 784$).],

--- a/docs/tesis.typ
+++ b/docs/tesis.typ
@@ -2311,8 +2311,6 @@ Asimismo, la grilla de $alpha in [1, 4]$ utilizada en nuestros experimentos podr
 
 
 #if anexo-ia [
-  #pagebreak()
-
   #heading(numbering: none, level: 1)[Anexo: Disquisiciones con IA]
 
   Este anexo cataloga, con fines de transparencia y trazabilidad, el trabajo asistido por sistemas de inteligencia artificial (IA) realizado alrededor de esta tesis. Se incluye por dos motivos: registrar el flujo de trabajo declarado en `CLAUDE.md` --- según el cual la IA asistió en tareas de forma pero no de fondo --- y catalogar exploraciones tangenciales generadas por IA que exceden el alcance del cuerpo de esta monografía pero que quedan como pistas para investigación futura. Nada de lo consignado en este anexo debe interpretarse como contribución matemática original del autor, ni como conclusión validada de la tesis.


### PR DESCRIPTION
## Resumen
Dos mejoras visuales pequeñas sobre el PDF entregado:

1. **Elimina \`#pagebreak()\` al inicio del anexo IA** — antes forzaba la última oración de \"Trabajo Futuro\" a caer en una p107 casi vacía (solo 2 líneas de tail). Sin el pagebreak, el heading del anexo fluye después de Conclusiones en la misma página, densificando el layout. Total 115→114 páginas.

2. **Agranda Figura 32 con \`wide_figure(width: 130%)\`** — la única figura de §4.4.11 \"Datasets de alta dimensionalidad\" era estrecha y dejaba p101 con mucho blanco. Al ensanchar, ocupa mejor la caja de la página.

## Justificación
Cambios exclusivamente de forma; no afecta contenido matemático, resultados ni interpretación. Verificado con \`typst compile\` + inspección visual página por página.

🤖 Asistido por IA (Claude)